### PR TITLE
[FEAT] Drawer 컴포넌트를 Controlled, UnControlled 버전으로 분기

### DIFF
--- a/src/components/drawer/Drawer.tsx
+++ b/src/components/drawer/Drawer.tsx
@@ -1,9 +1,14 @@
-import { type ComponentProps, createContext, useContext, useMemo } from 'react';
+import {
+    type ComponentProps,
+    type Dispatch,
+    type SetStateAction,
+    createContext,
+    useContext,
+    useMemo,
+} from 'react';
 
 import * as Dialog from '@radix-ui/react-dialog';
 import { AnimatePresence, MotionValue, useMotionValue } from 'framer-motion';
-
-import { useDisclosure } from '#/hooks/useDisclosure';
 
 import { DrawerClose } from './DrawerClose';
 import { DrawerContent } from './DrawerContent';
@@ -20,34 +25,32 @@ const DrawerContext = createContext<DrawerContextType | null>(null);
 
 interface DrawerRootProps
     extends Omit<ComponentProps<typeof Dialog.Root>, 'open' | 'onOpenChange'> {
-    initialOpen?: boolean;
+    isDrawerOpen: boolean;
+    setDrawerOpen: Dispatch<SetStateAction<boolean>>;
 }
 
 export const DrawerRoot = ({
     children,
-    initialOpen = false,
+    isDrawerOpen,
+    setDrawerOpen,
     ...restProps
 }: DrawerRootProps) => {
-    const {
-        state: isDrawerOpen,
-        setTrue: openDrawer,
-        setFalse: closeDrawer,
-    } = useDisclosure(initialOpen);
-
     const currentHeightIndex = useMotionValue(0);
 
     const handleChangeDrawerOpen = () => {
         currentHeightIndex.set(0);
     };
 
+    console.log(isDrawerOpen);
+
     const value = useMemo(
         () => ({
             isDrawerOpen,
             currentHeightIndex,
-            openDrawer,
-            closeDrawer,
+            openDrawer: () => setDrawerOpen(true),
+            closeDrawer: () => setDrawerOpen(false),
         }),
-        [isDrawerOpen, currentHeightIndex, openDrawer, closeDrawer],
+        [isDrawerOpen, currentHeightIndex, setDrawerOpen],
     );
 
     return (

--- a/src/components/drawer/Drawer.tsx
+++ b/src/components/drawer/Drawer.tsx
@@ -41,8 +41,6 @@ export const DrawerRoot = ({
         currentHeightIndex.set(0);
     };
 
-    console.log(isDrawerOpen);
-
     const value = useMemo(
         () => ({
             isDrawerOpen,

--- a/src/components/drawer/DrawerContent.tsx
+++ b/src/components/drawer/DrawerContent.tsx
@@ -24,7 +24,7 @@ type DrawerContentProps = PropsWithChildren<{
 export const DrawerContent = ({
     children,
     heightStepList,
-    threshold = 30,
+    threshold = 20,
     ...restProps
 }: DrawerContentProps) => {
     const { isDrawerOpen, currentHeightIndex, closeDrawer } =
@@ -80,7 +80,13 @@ export const DrawerContent = ({
                             onClick={closeDrawer}
                         />
                     </Dialog.Overlay>
-                    <Dialog.Content forceMount asChild {...restProps}>
+                    <Dialog.Content
+                        forceMount
+                        aria-describedby={undefined}
+                        aria-label="Drawer"
+                        asChild
+                        {...restProps}
+                    >
                         <S.ContentWrapper
                             initial={{ opacity: 0, y: '100%' }}
                             animate={{ opacity: 1, y: '0%' }}

--- a/src/components/uncontrolled-drawer/UnControlledDrawer.style.tsx
+++ b/src/components/uncontrolled-drawer/UnControlledDrawer.style.tsx
@@ -1,0 +1,64 @@
+import styled from '@emotion/styled';
+import { motion } from 'framer-motion';
+
+import { theme } from '#/styles/theme';
+
+export const Overlay = styled(motion.div)`
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.7);
+`;
+
+export const ContentWrapper = styled(motion.div)`
+    position: fixed;
+    width: 375px;
+    max-width: 375px;
+    max-height: 90dvh;
+
+    padding: 0 16px 16px 16px;
+
+    transform: translate(-50%, -50%);
+    transition:
+        height 0.1s cubic-bezier(0.14, 0.99, 0.98, 0.98),
+        top 0.1s cubic-bezier(0.14, 0.99, 0.98, 0.98);
+
+    background-color: ${theme.color.wht[100]};
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    border-radius: 16px 16px 0 0;
+
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+
+    overflow: hidden;
+`;
+
+export const Content = styled.div`
+    flex: 1;
+    overflow: auto;
+`
+
+export const HolderWrapper = styled(motion.div)`
+    width: 375px;
+    padding: 16px;
+
+    background-color: ${theme.color.wht[100]};
+    border-radius: 16px 16px 0 0;
+
+    display: flex;
+    justify-content: center;
+    align-self: center;
+
+    cursor: grab;
+`;
+
+export const Holder = styled.div`
+    width: 32px;
+    height: 4px;
+
+    background-color: ${theme.color.blk[20]};
+    border-radius: 100px;
+`;

--- a/src/components/uncontrolled-drawer/UnControlledDrawer.tsx
+++ b/src/components/uncontrolled-drawer/UnControlledDrawer.tsx
@@ -1,0 +1,81 @@
+import { type ComponentProps, createContext, useContext, useMemo } from 'react';
+
+import * as Dialog from '@radix-ui/react-dialog';
+import { AnimatePresence, MotionValue, useMotionValue } from 'framer-motion';
+
+import { useDisclosure } from '#/hooks/useDisclosure';
+
+import { UnControlledDrawerClose } from './UnControlledDrawerClose';
+import { UnControlledDrawerContent } from './UnControlledDrawerContent';
+import { UnControlledDrawerTrigger } from './UnControlledDrawerTrigger';
+
+interface UnControlledDrawerContextType {
+    isDrawerOpen: boolean;
+    currentHeightIndex: MotionValue<number>;
+    openDrawer: () => void;
+    closeDrawer: () => void;
+}
+
+const DrawerContext = createContext<UnControlledDrawerContextType | null>(null);
+
+interface UnControlledDrawerRootProps
+    extends Omit<ComponentProps<typeof Dialog.Root>, 'open' | 'onOpenChange'> {
+    initialOpen?: boolean;
+}
+
+export const UnControlledDrawerRoot = ({
+    children,
+    initialOpen = false,
+    ...restProps
+}: UnControlledDrawerRootProps) => {
+    const {
+        state: isDrawerOpen,
+        setTrue: openDrawer,
+        setFalse: closeDrawer,
+    } = useDisclosure(initialOpen);
+
+    const currentHeightIndex = useMotionValue(0);
+
+    const handleChangeDrawerOpen = () => {
+        currentHeightIndex.set(0);
+    };
+
+    const value = useMemo(
+        () => ({
+            isDrawerOpen,
+            currentHeightIndex,
+            openDrawer,
+            closeDrawer,
+        }),
+        [isDrawerOpen, currentHeightIndex, openDrawer, closeDrawer],
+    );
+
+    return (
+        <DrawerContext.Provider value={value}>
+            <Dialog.Root
+                open={isDrawerOpen}
+                onOpenChange={handleChangeDrawerOpen}
+                {...restProps}
+            >
+                <AnimatePresence>{children}</AnimatePresence>
+            </Dialog.Root>
+        </DrawerContext.Provider>
+    );
+};
+
+export const useUnControlledDrawerContext = () => {
+    const drawerContext = useContext(DrawerContext);
+
+    if (!drawerContext)
+        throw new Error(
+            'useDrawerContext 는 Drawer 컴포넌트 내부에서만 사용해야 합니다.',
+        );
+
+    return drawerContext;
+};
+
+export const UnControlledDrawer = Object.assign(UnControlledDrawerRoot, {
+    Trigger: UnControlledDrawerTrigger,
+    Close: UnControlledDrawerClose,
+    Content: UnControlledDrawerContent,
+});

--- a/src/components/uncontrolled-drawer/UnControlledDrawerClose.tsx
+++ b/src/components/uncontrolled-drawer/UnControlledDrawerClose.tsx
@@ -1,0 +1,22 @@
+import type { ComponentProps } from 'react';
+
+import * as Dialog from '@radix-ui/react-dialog';
+
+import { useUnControlledDrawerContext } from './UnControlledDrawer';
+
+type UnControlledDrawerCloseProps = Omit<
+    ComponentProps<typeof Dialog.Close>,
+    'asChild'
+>;
+
+export const UnControlledDrawerClose = ({
+    children,
+    ...restProps
+}: UnControlledDrawerCloseProps) => {
+    const { closeDrawer } = useUnControlledDrawerContext();
+    return (
+        <Dialog.Close onClick={closeDrawer} asChild {...restProps}>
+            {children}
+        </Dialog.Close>
+    );
+};

--- a/src/components/uncontrolled-drawer/UnControlledDrawerContent.tsx
+++ b/src/components/uncontrolled-drawer/UnControlledDrawerContent.tsx
@@ -24,7 +24,7 @@ type UnControlledDrawerContentProps = PropsWithChildren<{
 export const UnControlledDrawerContent = ({
     children,
     heightStepList,
-    threshold = 30,
+    threshold = 20,
     ...restProps
 }: UnControlledDrawerContentProps) => {
     const { isDrawerOpen, currentHeightIndex, closeDrawer } =
@@ -80,7 +80,13 @@ export const UnControlledDrawerContent = ({
                             onClick={closeDrawer}
                         />
                     </Dialog.Overlay>
-                    <Dialog.Content forceMount asChild {...restProps}>
+                    <Dialog.Content
+                        forceMount
+                        aria-describedby={undefined}
+                        aria-label="Drawer"
+                        asChild
+                        {...restProps}
+                    >
                         <S.ContentWrapper
                             initial={{ opacity: 0, y: '100%' }}
                             animate={{ opacity: 1, y: '0%' }}

--- a/src/components/uncontrolled-drawer/UnControlledDrawerContent.tsx
+++ b/src/components/uncontrolled-drawer/UnControlledDrawerContent.tsx
@@ -1,0 +1,106 @@
+import { type PropsWithChildren } from 'react';
+
+import * as Dialog from '@radix-ui/react-dialog';
+import {
+    AnimatePresence,
+    type PanInfo,
+    useMotionValue,
+    useTransform,
+} from 'framer-motion';
+
+import { useUnControlledDrawerContext } from './UnControlledDrawer';
+import * as S from './UnControlledDrawer.style';
+
+type HeightStepType = {
+    unit: 'px' | 'dvh' | 'vh' | '%';
+    value: number;
+};
+
+type UnControlledDrawerContentProps = PropsWithChildren<{
+    heightStepList: HeightStepType[];
+    threshold?: number;
+}>;
+
+export const UnControlledDrawerContent = ({
+    children,
+    heightStepList,
+    threshold = 30,
+    ...restProps
+}: UnControlledDrawerContentProps) => {
+    const { isDrawerOpen, currentHeightIndex, closeDrawer } =
+        useUnControlledDrawerContext();
+
+    const startY = useMotionValue(0);
+
+    const stepAmount = heightStepList.length;
+    const [stepUnitList, stepValueList] = heightStepList.reduce<
+        [string[], number[]]
+    >(
+        ([currentUnitList, currentValueList], { unit, value }) => [
+            [...currentUnitList, unit],
+            [...currentValueList, value],
+        ],
+        [[], []],
+    );
+
+    const height = useTransform(
+        currentHeightIndex,
+        (index) => `${stepValueList[index]}${stepUnitList[index]}`,
+    );
+
+    const top = useTransform(height, (h) => `calc(100dvh - ${h})`);
+
+    const handlePanStart = (_event: PointerEvent, info: PanInfo) => {
+        startY.set(info.point.y);
+    };
+
+    const handlePanEnd = (_event: PointerEvent, info: PanInfo) => {
+        const deltaY = info.point.y - startY.get();
+        let updatedHeightIndex = currentHeightIndex.get();
+
+        if (deltaY < -threshold && updatedHeightIndex < stepAmount - 1) {
+            updatedHeightIndex += 1;
+        } else if (deltaY > threshold && updatedHeightIndex > 0) {
+            updatedHeightIndex > 0 ? (updatedHeightIndex -= 1) : closeDrawer();
+        }
+
+        currentHeightIndex.set(updatedHeightIndex);
+    };
+
+    return (
+        <AnimatePresence>
+            {isDrawerOpen && (
+                <>
+                    <Dialog.Overlay forceMount asChild>
+                        <S.Overlay
+                            initial={{ opacity: 0 }}
+                            animate={{ opacity: 1 }}
+                            exit={{ opacity: 0 }}
+                            transition={{ duration: 0.3 }}
+                            onClick={closeDrawer}
+                        />
+                    </Dialog.Overlay>
+                    <Dialog.Content forceMount asChild {...restProps}>
+                        <S.ContentWrapper
+                            initial={{ opacity: 0, y: '100%' }}
+                            animate={{ opacity: 1, y: '0%' }}
+                            exit={{ opacity: 0, y: '100%' }}
+                            style={{
+                                height,
+                                top,
+                            }}
+                            layout
+                            onPanStart={handlePanStart}
+                            onPanEnd={handlePanEnd}
+                        >
+                            <S.HolderWrapper>
+                                <S.Holder />
+                            </S.HolderWrapper>
+                            <S.Content>{children}</S.Content>
+                        </S.ContentWrapper>
+                    </Dialog.Content>
+                </>
+            )}
+        </AnimatePresence>
+    );
+};

--- a/src/components/uncontrolled-drawer/UnControlledDrawerTrigger.tsx
+++ b/src/components/uncontrolled-drawer/UnControlledDrawerTrigger.tsx
@@ -1,0 +1,23 @@
+import type { ComponentProps } from 'react';
+
+import * as Dialog from '@radix-ui/react-dialog';
+
+import { useUnControlledDrawerContext } from './UnControlledDrawer';
+
+type UnControlledDrawerTriggerProps = Omit<
+    ComponentProps<typeof Dialog.Trigger>,
+    'asChild'
+>;
+
+export const UnControlledDrawerTrigger = ({
+    children,
+    ...restProps
+}: UnControlledDrawerTriggerProps) => {
+    const { openDrawer } = useUnControlledDrawerContext();
+
+    return (
+        <Dialog.Trigger onClick={openDrawer} asChild {...restProps}>
+            {children}
+        </Dialog.Trigger>
+    );
+};

--- a/src/components/uncontrolled-drawer/index.ts
+++ b/src/components/uncontrolled-drawer/index.ts
@@ -1,0 +1,1 @@
+export { UnControlledDrawer } from './UnControlledDrawer';


### PR DESCRIPTION
## Task Summary ✨
Drawer 컴포넌트를 Controlled 버전, Uncontrolled 버전으로 분기

## Description 📑
- Drawer 의 열림 여부를 외부로부터 받아 사용하는 Drawer 컴포넌트 추가
- Drawer 의 열림 여부를 내부에서 관리하여, 외부에서 상태를 접근하지 못하는 UnControlledDrawer 컴포넌트 추가

## More Information 🛎 (Optional)
- 처음에는 Drawer 컴포넌트 한 곳에서 제어, 비제어를 다 담을까 했는데 그러면 너무 로직이 이상해져서 분리했어!
- @jhj2713 효정이 너가 고민한 점은 "Drawer" 를 외부에서 제어하고 싶으니까, Drawer 컴포넌트를 그대로 사용하면 돼!
- 만약 Drawer 컴포넌트의 상태를 외부에서 직접 제어할 필요가 없다면 UnControlledDrawer 를 사용하면 되도록 했어!

## Self Checklist ✅
- [x] PR 제목 컨벤션에 맞는지 확인
- [x] PR Label 설정