### PR TITLE
[FEAT] 공용 컴포넌트 Text 추가

### DIFF
--- a/src/components/text/Text.style.tsx
+++ b/src/components/text/Text.style.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import styled from '@emotion/styled';
 
 import { theme } from '#/styles/theme';
 
@@ -6,9 +7,11 @@ import type { TextProps } from './Text';
 
 type TextStyleProps = Pick<TextProps, 'color' | 'typography'>;
 
-export const textStyle = ({ color, typography }: TextStyleProps) => css`
-    color: ${color ?? theme.color.blk[100]};
-    font-size: ${theme.typography[typography].fontSize};
-    font-weight: ${theme.typography[typography].fontWeight};
-    line-height: ${theme.typography[typography].lineHeight};
-`;
+export const Container = styled.p(
+    ({ color, typography }: TextStyleProps) => css`
+        color: ${color ?? theme.color.blk[100]};
+        font-size: ${theme.typography[typography].fontSize};
+        font-weight: ${theme.typography[typography].fontWeight};
+        line-height: ${theme.typography[typography].lineHeight};
+    `,
+);

--- a/src/components/text/Text.style.tsx
+++ b/src/components/text/Text.style.tsx
@@ -1,0 +1,14 @@
+import { css } from '@emotion/react';
+
+import { theme } from '#/styles/theme';
+
+import type { TextProps } from './Text';
+
+type TextStyleProps = Pick<TextProps, 'color' | 'typography'>;
+
+export const textStyle = ({ color, typography }: TextStyleProps) => css`
+    color: ${color ?? theme.color.blk[100]};
+    font-size: ${theme.typography[typography].fontSize};
+    font-weight: ${theme.typography[typography].fontWeight};
+    line-height: ${theme.typography[typography].lineHeight};
+`;

--- a/src/components/text/Text.tsx
+++ b/src/components/text/Text.tsx
@@ -1,0 +1,32 @@
+import { ElementType, HTMLAttributes } from 'react';
+
+import { FONT_STYLE_NAME } from '#/styles/font';
+
+import { textStyle } from './Text.style';
+
+export interface TextProps extends HTMLAttributes<HTMLElement> {
+    as?: ElementType;
+    color?: string;
+    typography: keyof typeof FONT_STYLE_NAME;
+    className: string;
+}
+
+export const Text = ({
+    children,
+    color,
+    typography,
+    className,
+    as,
+    ...restProps
+}: TextProps) => {
+    const TextComponent = as || 'p';
+    return (
+        <TextComponent
+            className={className}
+            css={textStyle({ color, typography })}
+            {...restProps}
+        >
+            {children}
+        </TextComponent>
+    );
+};

--- a/src/components/text/Text.tsx
+++ b/src/components/text/Text.tsx
@@ -2,31 +2,30 @@ import { ElementType, HTMLAttributes } from 'react';
 
 import { FONT_STYLE_NAME } from '#/styles/font';
 
-import { textStyle } from './Text.style';
+import * as S from './Text.style';
 
 export interface TextProps extends HTMLAttributes<HTMLElement> {
     as?: ElementType;
     color?: string;
+    className?: string;
     typography: keyof typeof FONT_STYLE_NAME;
-    className: string;
 }
 
 export const Text = ({
     children,
     color,
     typography,
-    className,
     as,
     ...restProps
 }: TextProps) => {
-    const TextComponent = as || 'p';
     return (
-        <TextComponent
-            className={className}
-            css={textStyle({ color, typography })}
+        <S.Container
+            as={as || 'p'}
+            color={color}
+            typography={typography}
             {...restProps}
         >
             {children}
-        </TextComponent>
+        </S.Container>
     );
 };

--- a/src/components/text/index.ts
+++ b/src/components/text/index.ts
@@ -1,0 +1,1 @@
+export { Text } from './Text';

--- a/src/styles/color.ts
+++ b/src/styles/color.ts
@@ -48,7 +48,7 @@ const error = {
     100: '#FF3B30',
 } as const;
 
-const naver = '#34C11D';
+const naver = '#34C11D' as const;
 
 export const COLOR = {
     blk,

--- a/src/styles/font.ts
+++ b/src/styles/font.ts
@@ -1,13 +1,113 @@
 export const FONT_FAMILY = {
     suit: 'SUIT Variable',
-}
+};
+
+export const FONT_STYLE_NAME = {
+    heading1: 'heading1',
+    heading2: 'heading2',
+    heading3: 'heading3',
+    heading4: 'heading4',
+    body1: 'body1',
+    body2: 'body2',
+    body3: 'body3',
+    body4: 'body4',
+    body5: 'body5',
+    body6: 'body6',
+    body7: 'body7',
+    smallText1: 'smallText1',
+    smallText2: 'smallText2',
+    button1: 'button1',
+    button2: 'button2',
+    caption: 'caption',
+} as const;
+
+const LINE_HEIGHT_RATIO = 1.5;
 
 export const FONT_WEIGHT = {
-    light: 300,
-    regular: 400,
     medium: 500,
     semiBold: 600,
     bold: 700,
-    extraBold: 800,
-    black: 900,
+} as const;
+
+export const TYPOGRAPHY = {
+    [FONT_STYLE_NAME.heading1]: {
+        fontSize: '24px',
+        lineHeight: `${LINE_HEIGHT_RATIO * 24}px`,
+        fontWeight: FONT_WEIGHT.bold,
+    },
+    [FONT_STYLE_NAME.heading2]: {
+        fontSize: '20px',
+        lineHeight: `${LINE_HEIGHT_RATIO * 20}px`,
+        fontWeight: FONT_WEIGHT.bold,
+    },
+    [FONT_STYLE_NAME.heading3]: {
+        fontSize: '20px',
+        lineHeight: `${LINE_HEIGHT_RATIO * 20}px`,
+        fontWeight: FONT_WEIGHT.semiBold,
+    },
+    [FONT_STYLE_NAME.heading4]: {
+        fontSize: '18px',
+        lineHeight: `${LINE_HEIGHT_RATIO * 18}px`,
+        fontWeight: FONT_WEIGHT.bold,
+    },
+    [FONT_STYLE_NAME.body1]: {
+        fontSize: '18px',
+        lineHeight: `${LINE_HEIGHT_RATIO * 18}px`,
+        fontWeight: FONT_WEIGHT.semiBold,
+    },
+    [FONT_STYLE_NAME.body2]: {
+        fontSize: '16px',
+        lineHeight: `${LINE_HEIGHT_RATIO * 16}px`,
+        fontWeight: FONT_WEIGHT.bold,
+    },
+    [FONT_STYLE_NAME.body3]: {
+        fontSize: '16px',
+        lineHeight: `${LINE_HEIGHT_RATIO * 16}px`,
+        fontWeight: FONT_WEIGHT.semiBold,
+    },
+    [FONT_STYLE_NAME.body4]: {
+        fontSize: '16px',
+        lineHeight: `${LINE_HEIGHT_RATIO * 16}px`,
+        fontWeight: FONT_WEIGHT.medium,
+    },
+    [FONT_STYLE_NAME.body5]: {
+        fontSize: '14px',
+        lineHeight: `${LINE_HEIGHT_RATIO * 14}px`,
+        fontWeight: FONT_WEIGHT.bold,
+    },
+    [FONT_STYLE_NAME.body6]: {
+        fontSize: '14px',
+        lineHeight: `${LINE_HEIGHT_RATIO * 14}px`,
+        fontWeight: FONT_WEIGHT.semiBold,
+    },
+    [FONT_STYLE_NAME.body7]: {
+        fontSize: '14px',
+        lineHeight: `${LINE_HEIGHT_RATIO * 14}px`,
+        fontWeight: FONT_WEIGHT.medium,
+    },
+    [FONT_STYLE_NAME.button1]: {
+        fontSize: '16px',
+        lineHeight: `${LINE_HEIGHT_RATIO * 16}px`,
+        fontWeight: FONT_WEIGHT.bold,
+    },
+    [FONT_STYLE_NAME.button2]: {
+        fontSize: '14px',
+        lineHeight: `${LINE_HEIGHT_RATIO * 14}px`,
+        fontWeight: FONT_WEIGHT.bold,
+    },
+    [FONT_STYLE_NAME.caption]: {
+        fontSize: '12px',
+        lineHeight: `${LINE_HEIGHT_RATIO * 12}px`,
+        fontWeight: FONT_WEIGHT.semiBold,
+    },
+    [FONT_STYLE_NAME.smallText1]: {
+        fontSize: '12px',
+        lineHeight: `${LINE_HEIGHT_RATIO * 12}px`,
+        fontWeight: FONT_WEIGHT.semiBold,
+    },
+    [FONT_STYLE_NAME.smallText2]: {
+        fontSize: '12px',
+        lineHeight: `${LINE_HEIGHT_RATIO * 12}px`,
+        fontWeight: FONT_WEIGHT.medium,
+    },
 } as const;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,10 +1,11 @@
 import { COLOR } from './color';
-import { FONT_WEIGHT, FONT_FAMILY } from './font';
+import { FONT_FAMILY, FONT_WEIGHT, TYPOGRAPHY } from './font';
 
 export const theme = {
     color: COLOR,
     font: {
         family: FONT_FAMILY,
         weight: FONT_WEIGHT,
-    }
+    },
+    typography: TYPOGRAPHY,
 } as const;


### PR DESCRIPTION
## Task Summary ✨
공용 컴포넌트 Text 추가

## Description 📑
- Figma 에 정의된 Design System 에 맞춰 Foundation 을 추가했습니다.
- color 토큰과 typography 를 조합하여 Text 를 반환하는 공용 컴포넌트를 제작했습니다.

## More Information 🛎 (Optional)
- `as` props 를 추가해서 Text 가 렌더링 될 컴포넌트를 지정할 수 있도록 사용성을 높혔어!
- 다만 Figma 에서는 Typography 에 대한 토큰이 적용되지 않아서, 일단 시안을 보고 Typo 를 유추해야 할 거 같아..
- 혹시 공용 컴포넌트 관련해서 추가로 논의할 사항이 있다면 언제든지 코멘트 남겨줘!

## Self Checklist ✅
- [x] PR 제목 컨벤션에 맞는지 확인
- [x] PR Label 설정