### PR TITLE
[FEAT] 주유 및 주차 정보 페이지 구현

### DIFF
--- a/src/features/rest-area/rest-area-fuel-information/RestAreaFuelInformation.style.tsx
+++ b/src/features/rest-area/rest-area-fuel-information/RestAreaFuelInformation.style.tsx
@@ -23,3 +23,13 @@ export const Card = styled(FlexBox)`
     flex-grow: 1;
 `
 
+export const AvailableChargeOption = styled(FlexBox)`
+    width: 100%;
+    align-items: center;
+`
+
+export const DashedLine = styled.div`
+    flex-grow: 1;
+    height: 1px;
+    border-bottom: 1px dashed ${theme.color.blk[10]}
+`

--- a/src/features/rest-area/rest-area-fuel-information/RestAreaFuelInformation.style.tsx
+++ b/src/features/rest-area/rest-area-fuel-information/RestAreaFuelInformation.style.tsx
@@ -1,0 +1,25 @@
+import styled from '@emotion/styled';
+
+import { FlexBox } from '#/components/flex-box';
+import { theme } from '#/styles/theme';
+
+export const Section = styled(FlexBox)`
+    padding: 40px 20px;
+    background-color: ${theme.color.wht[100]};
+`;
+
+export const Title = styled(FlexBox)`
+    align-items: center;
+`;
+
+export const CardGroup = styled(FlexBox)`
+    width: 100%;
+    align-items: center;
+`
+
+export const Card = styled(FlexBox)`
+    padding: 24px;
+    align-items: center;
+    flex-grow: 1;
+`
+

--- a/src/features/rest-area/rest-area-fuel-information/RestAreaFuelInformation.style.tsx
+++ b/src/features/rest-area/rest-area-fuel-information/RestAreaFuelInformation.style.tsx
@@ -21,6 +21,8 @@ export const Card = styled(FlexBox)`
     padding: 24px;
     align-items: center;
     flex-grow: 1;
+    text-align: center;
+    white-space: nowrap;
 `
 
 export const AvailableChargeOption = styled(FlexBox)`

--- a/src/features/rest-area/rest-area-fuel-information/RestAreaFuelInformation.tsx
+++ b/src/features/rest-area/rest-area-fuel-information/RestAreaFuelInformation.tsx
@@ -1,3 +1,4 @@
+import { FlexBox } from '#/components/flex-box';
 import { Text } from '#/components/text';
 import { theme } from '#/styles/theme';
 
@@ -7,12 +8,16 @@ interface RestAreaFuelInformationProps {
     gasolinePrice?: number;
     dieselPrice?: number;
     lpgPrice?: number;
+    isElectricChargeAvailable?: boolean;
+    isHydrogenChargeAvailable?: boolean;
 }
 
 export const RestAreaFuelInformation = ({
     gasolinePrice,
     dieselPrice,
     lpgPrice,
+    isElectricChargeAvailable,
+    isHydrogenChargeAvailable,
 }: RestAreaFuelInformationProps) => {
     return (
         <S.Section gap={24}>
@@ -28,40 +33,81 @@ export const RestAreaFuelInformation = ({
                 </Text>
             </S.Title>
             <S.CardGroup row gap={12}>
-                {gasolinePrice && <S.Card gap={20}>
-                    <Text color={theme.color.blk[60]} typography="bodyMedium16">
-                        휘발유
-                    </Text>
-                    <Text
-                        color={theme.color.blk[100]}
-                        typography="headingBold18"
-                    >
-                        {gasolinePrice.toLocaleString()}원
-                    </Text>
-                </S.Card>}
-                {dieselPrice && <S.Card gap={20}>
-                    <Text color={theme.color.blk[60]} typography="bodyMedium16">
-                        경유
-                    </Text>
-                    <Text
-                        color={theme.color.blk[100]}
-                        typography="headingBold18"
-                    >
-                        {dieselPrice.toLocaleString()}원
-                    </Text>
-                </S.Card>}
-                {lpgPrice && <S.Card gap={20}>
-                    <Text color={theme.color.blk[60]} typography="bodyMedium16">
-                        LPG
-                    </Text>
-                    <Text
-                        color={theme.color.blk[100]}
-                        typography="headingBold18"
-                    >
-                        {lpgPrice.toLocaleString()}원
-                    </Text>
-                </S.Card>}
+                {gasolinePrice && (
+                    <S.Card gap={20}>
+                        <Text
+                            color={theme.color.blk[60]}
+                            typography="bodyMedium16"
+                        >
+                            휘발유
+                        </Text>
+                        <Text
+                            color={theme.color.blk[100]}
+                            typography="headingBold18"
+                        >
+                            {gasolinePrice.toLocaleString()}원
+                        </Text>
+                    </S.Card>
+                )}
+                {dieselPrice && (
+                    <S.Card gap={20}>
+                        <Text
+                            color={theme.color.blk[60]}
+                            typography="bodyMedium16"
+                        >
+                            경유
+                        </Text>
+                        <Text
+                            color={theme.color.blk[100]}
+                            typography="headingBold18"
+                        >
+                            {dieselPrice.toLocaleString()}원
+                        </Text>
+                    </S.Card>
+                )}
+                {lpgPrice && (
+                    <S.Card gap={20}>
+                        <Text
+                            color={theme.color.blk[60]}
+                            typography="bodyMedium16"
+                        >
+                            LPG
+                        </Text>
+                        <Text
+                            color={theme.color.blk[100]}
+                            typography="headingBold18"
+                        >
+                            {lpgPrice.toLocaleString()}원
+                        </Text>
+                    </S.Card>
+                )}
             </S.CardGroup>
+            <FlexBox gap={20}>
+                <S.AvailableChargeOption row gap={12}>
+                    <Text color={theme.color.blk[60]} typography="bodyMedium16">
+                        전기차 충전
+                    </Text>
+                    <S.DashedLine />
+                    <Text
+                        color={theme.color.blk[100]}
+                        typography="bodySemiBold16"
+                    >
+                        {isElectricChargeAvailable ? '가능' : '불가능'}
+                    </Text>
+                </S.AvailableChargeOption>
+                <S.AvailableChargeOption row gap={12}>
+                    <Text color={theme.color.blk[60]} typography="bodyMedium16">
+                        수소차 충전
+                    </Text>
+                    <S.DashedLine />
+                    <Text
+                        color={theme.color.blk[100]}
+                        typography="bodySemiBold16"
+                    >
+                        {isHydrogenChargeAvailable ? '가능' : '불가능'}
+                    </Text>
+                </S.AvailableChargeOption>
+            </FlexBox>
         </S.Section>
     );
 };

--- a/src/features/rest-area/rest-area-fuel-information/RestAreaFuelInformation.tsx
+++ b/src/features/rest-area/rest-area-fuel-information/RestAreaFuelInformation.tsx
@@ -45,7 +45,7 @@ export const RestAreaFuelInformation = ({
                             color={theme.color.blk[100]}
                             typography="headingBold18"
                         >
-                            {gasolinePrice.toLocaleString()}원
+                            {`${gasolinePrice.toLocaleString()}원`}
                         </Text>
                     </S.Card>
                 )}
@@ -61,7 +61,7 @@ export const RestAreaFuelInformation = ({
                             color={theme.color.blk[100]}
                             typography="headingBold18"
                         >
-                            {dieselPrice.toLocaleString()}원
+                            {`${dieselPrice.toLocaleString()}원`}
                         </Text>
                     </S.Card>
                 )}
@@ -77,7 +77,7 @@ export const RestAreaFuelInformation = ({
                             color={theme.color.blk[100]}
                             typography="headingBold18"
                         >
-                            {lpgPrice.toLocaleString()}원
+                            {`${lpgPrice.toLocaleString()}원`}
                         </Text>
                     </S.Card>
                 )}

--- a/src/features/rest-area/rest-area-fuel-information/RestAreaFuelInformation.tsx
+++ b/src/features/rest-area/rest-area-fuel-information/RestAreaFuelInformation.tsx
@@ -1,0 +1,67 @@
+import { Text } from '#/components/text';
+import { theme } from '#/styles/theme';
+
+import * as S from './RestAreaFuelInformation.style';
+
+interface RestAreaFuelInformationProps {
+    gasolinePrice?: number;
+    dieselPrice?: number;
+    lpgPrice?: number;
+}
+
+export const RestAreaFuelInformation = ({
+    gasolinePrice,
+    dieselPrice,
+    lpgPrice,
+}: RestAreaFuelInformationProps) => {
+    return (
+        <S.Section gap={24}>
+            <S.Title gap={12} row>
+                <img
+                    alt="주유 및 충전 표시 아이콘"
+                    src=""
+                    width={24}
+                    height={24}
+                />
+                <Text typography="headingBold20" color={theme.color.blk[100]}>
+                    주유 및 충전
+                </Text>
+            </S.Title>
+            <S.CardGroup row gap={12}>
+                {gasolinePrice && <S.Card gap={20}>
+                    <Text color={theme.color.blk[60]} typography="bodyMedium16">
+                        휘발유
+                    </Text>
+                    <Text
+                        color={theme.color.blk[100]}
+                        typography="headingBold18"
+                    >
+                        {gasolinePrice.toLocaleString()}원
+                    </Text>
+                </S.Card>}
+                {dieselPrice && <S.Card gap={20}>
+                    <Text color={theme.color.blk[60]} typography="bodyMedium16">
+                        경유
+                    </Text>
+                    <Text
+                        color={theme.color.blk[100]}
+                        typography="headingBold18"
+                    >
+                        {dieselPrice.toLocaleString()}원
+                    </Text>
+                </S.Card>}
+                {lpgPrice && <S.Card gap={20}>
+                    <Text color={theme.color.blk[60]} typography="bodyMedium16">
+                        LPG
+                    </Text>
+                    <Text
+                        color={theme.color.blk[100]}
+                        typography="headingBold18"
+                    >
+                        {lpgPrice.toLocaleString()}원
+                    </Text>
+                </S.Card>}
+            </S.CardGroup>
+        </S.Section>
+    );
+};

--- a/src/features/rest-area/rest-area-fuel-information/index.ts
+++ b/src/features/rest-area/rest-area-fuel-information/index.ts
@@ -1,0 +1,1 @@
+export { RestAreaFuelInformation } from './RestAreaFuelInformation';

--- a/src/features/rest-area/rest-area-parking-information/RestAreaParkingInformation.style.tsx
+++ b/src/features/rest-area/rest-area-parking-information/RestAreaParkingInformation.style.tsx
@@ -1,0 +1,28 @@
+import styled from '@emotion/styled';
+
+import { FlexBox } from '#/components/flex-box';
+import { theme } from '#/styles/theme';
+
+export const Section = styled(FlexBox)`
+    padding: 40px 20px;
+    background-color: ${theme.color.wht[100]};
+`;
+
+export const Title = styled(FlexBox)`
+    align-items: center;
+`;
+
+export const CardGroup = styled(FlexBox)`
+    width: 100%;
+    align-items: center;
+`
+
+export const Card = styled(FlexBox)`
+    padding: 24px;
+    align-items: center;
+    flex-grow: 1;
+`
+
+export const UpdateNotice = styled(FlexBox)`
+    margin-top: 8px;
+`

--- a/src/features/rest-area/rest-area-parking-information/RestAreaParkingInformation.style.tsx
+++ b/src/features/rest-area/rest-area-parking-information/RestAreaParkingInformation.style.tsx
@@ -21,6 +21,8 @@ export const Card = styled(FlexBox)`
     padding: 24px;
     align-items: center;
     flex-grow: 1;
+    text-align: center;
+    white-space: nowrap;
 `
 
 export const UpdateNotice = styled(FlexBox)`

--- a/src/features/rest-area/rest-area-parking-information/RestAreaParkingInformation.tsx
+++ b/src/features/rest-area/rest-area-parking-information/RestAreaParkingInformation.tsx
@@ -1,0 +1,114 @@
+import { FlexBox } from '#/components/flex-box';
+import { Text } from '#/components/text';
+import { theme } from '#/styles/theme';
+import dayjs from '#/utils/dayjs';
+
+import * as S from './RestAreaParkingInformation.style';
+
+interface RestAreaParkingInformationProps {
+    smallSizeParking?: number;
+    largeSizeParking?: number;
+    disabledOnlyParking?: number;
+    updatedInformationAt: Date;
+}
+
+export const RestAreaParkingInformation = ({
+    smallSizeParking,
+    largeSizeParking,
+    disabledOnlyParking,
+    updatedInformationAt,
+}: RestAreaParkingInformationProps) => {
+    const leftAvailableParking = [
+        smallSizeParking,
+        largeSizeParking,
+        disabledOnlyParking,
+    ].reduce<number>((total, current) => total + (current ?? 0), 0);
+
+    return (
+        <S.Section gap={32}>
+            <FlexBox row flexOption={{ justifyContent: 'space-between', alignItems: 'center' }}>
+                <S.Title row gap={12}>
+                    <img
+                        alt="주차 공간 표시 아이콘"
+                        src=""
+                        width={24}
+                        height={24}
+                    />
+                    <Text
+                        typography="headingBold20"
+                        color={theme.color.blk[100]}
+                    >
+                        주차 공간
+                    </Text>
+                </S.Title>
+                <Text color={theme.color.blk[40]} typography="bodySemiBold14">
+                    {leftAvailableParking}대 주차 가능
+                </Text>
+            </FlexBox>
+            <S.CardGroup row gap={12}>
+                {smallSizeParking && (
+                    <S.Card gap={20}>
+                        <Text
+                            color={theme.color.blk[60]}
+                            typography="bodyMedium16"
+                        >
+                            소형
+                        </Text>
+                        <Text
+                            color={theme.color.blk[100]}
+                            typography="headingBold18"
+                        >
+                            {smallSizeParking}대
+                        </Text>
+                    </S.Card>
+                )}
+                {largeSizeParking && (
+                    <S.Card gap={20}>
+                        <Text
+                            color={theme.color.blk[60]}
+                            typography="bodyMedium16"
+                        >
+                            대형
+                        </Text>
+                        <Text
+                            color={theme.color.blk[100]}
+                            typography="headingBold18"
+                        >
+                            {largeSizeParking}대
+                        </Text>
+                    </S.Card>
+                )}
+                {disabledOnlyParking && (
+                    <S.Card gap={20}>
+                        <Text
+                            color={theme.color.blk[60]}
+                            typography="bodyMedium16"
+                        >
+                            장애인
+                        </Text>
+                        <Text
+                            color={theme.color.blk[100]}
+                            typography="headingBold18"
+                        >
+                            {disabledOnlyParking}대
+                        </Text>
+                    </S.Card>
+                )}
+            </S.CardGroup>
+            <S.UpdateNotice gap={8}>
+                <Text
+                    typography="smallTextMedium12"
+                    color={theme.color.blk[30]}
+                >
+                    {dayjs(updatedInformationAt).format('YYYY.MM.DD')} 업데이트
+                </Text>
+                <Text
+                    typography="smallTextMedium12"
+                    color={theme.color.blk[30]}
+                >
+                    본 정보는 특정 시점에 수집되어 실제와 다를 수 있습니다.
+                </Text>
+            </S.UpdateNotice>
+        </S.Section>
+    );
+};

--- a/src/features/rest-area/rest-area-parking-information/index.ts
+++ b/src/features/rest-area/rest-area-parking-information/index.ts
@@ -1,0 +1,1 @@
+export { RestAreaParkingInformation } from './RestAreaParkingInformation';

--- a/src/pages/rest-area-fuel/RestAreaFuelPage.style.tsx
+++ b/src/pages/rest-area-fuel/RestAreaFuelPage.style.tsx
@@ -1,0 +1,9 @@
+import styled from '@emotion/styled';
+
+import { FlexBox } from '#/components/flex-box';
+import { theme } from '#/styles/theme';
+
+export const Container = styled(FlexBox)`
+    width: 100%;
+    background-color:#F9F9F9
+`

--- a/src/pages/rest-area-fuel/RestAreaFuelPage.tsx
+++ b/src/pages/rest-area-fuel/RestAreaFuelPage.tsx
@@ -1,0 +1,38 @@
+import { RestAreaFuelInformation } from '#/features/rest-area/rest-area-fuel-information';
+import { RestAreaParkingInformation } from '#/features/rest-area/rest-area-parking-information';
+
+import * as S from './RestAreaFuelPage.style';
+
+const RestAreaInformation = {
+    fuel: {
+        gasolinePrice: 1234,
+        dieselPrice: 1522,
+        lpgPrice: 978,
+    },
+    parking: {
+        smallSizeParking: 236,
+        largeSizeParking: 23,
+        disabledOnlyParking: 12,
+        updatedInformationAt: new Date('2024-08-11'),
+    },
+};
+
+export const RestAreaFuelPage = () => {
+    const { fuel, parking } = RestAreaInformation;
+
+    return (
+        <S.Container gap={8}>
+            <RestAreaFuelInformation
+                gasolinePrice={fuel.gasolinePrice}
+                dieselPrice={fuel.dieselPrice}
+                lpgPrice={fuel.lpgPrice}
+            />
+            <RestAreaParkingInformation 
+                    smallSizeParking={parking.smallSizeParking}
+                    largeSizeParking={parking.largeSizeParking}
+                    disabledOnlyParking={parking.disabledOnlyParking}
+                    updatedInformationAt={parking.updatedInformationAt}
+            />
+        </S.Container>
+    );
+};

--- a/src/pages/rest-area-fuel/index.ts
+++ b/src/pages/rest-area-fuel/index.ts
@@ -1,0 +1,1 @@
+export { RestAreaFuelPage } from './RestAreaFuelPage';

--- a/src/styles/global.tsx
+++ b/src/styles/global.tsx
@@ -1,8 +1,13 @@
 import { Global, css } from '@emotion/react';
 
-import { theme } from './theme';
-
 const globalCss = css`
+    @font-face {
+        font-family: 'SUIT Variable';
+        font-weight: 100 900;
+        src: url('./src/assets/fonts/SUIT-Variable.woff2')
+            format('woff2-variations');
+    }
+
     *,
     *::before,
     *::after {
@@ -66,16 +71,9 @@ const globalCss = css`
         scroll-behavior: smooth;
         margin: 0;
 
-        font-family: ${theme.font.family.suit};
+        font-family: 'SUIT Variable';
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
-    }
-
-    @font-face {
-        font-family: 'SUIT Variable';
-        font-weight: 100 900;
-        src: url('./src/assets/fonts/SUIT-Variable.woff2')
-            format('woff2-variations');
     }
 `;
 


### PR DESCRIPTION
## Task Summary ✨
주유 및 주차 정보 페이지 구현

## Description 📑
- 휴게소 별 주유 (휘발유, 경유, LPG) 가격을 제공하는 Section 컴포넌트를 개발했습니다.
- 휴게소 별 주차 (소형, 대형, 장애인 전용) 잔여 공간 수를 제공하는 Section 컴포넌트를 개발했습니다. 
- 두 정보를 하나로 묶어 Page 컴포넌트를 개발했습니다.

## More Information 🛎 (Optional)
- Title, Section 이 현재 연속적으로 나오고 있는데 요걸 공용 컴포넌트화 해도 괜찮은지가 궁금해.

```tsx
  <S.Section gap={24}>
            <S.Title gap={12} row>
                <img
                    alt="주유 및 충전 표시 아이콘"
                    src=""
                    width={24}
                    height={24}
                />
                <Text typography="headingBold20" color={theme.color.blk[100]}>
                    주유 및 충전
                </Text>
            </S.Title>
  <S.Section gap={24}>
```

- 최종 구현 이미지는 아래와 같아~
![333](https://github.com/user-attachments/assets/3219f193-e420-4edd-a31c-16309bd0dc8d)


## Self Checklist ✅
- [x] PR 제목 컨벤션에 맞는지 확인
- [x] PR Label 설정