### PR TITLE
[FEAT] 휴게소 목록 및 상세 정보 API 추가 및 Type 정의

### DIFF
--- a/src/apis/api.ts
+++ b/src/apis/api.ts
@@ -1,8 +1,10 @@
 import axios, { type AxiosRequestConfig, type AxiosResponse } from 'axios';
 
 export const API = {
-    get: async <T>(url: string, params?: T) => {
-        const response = await axios.get(url, { params });
+    get: async <T, D = unknown>(url: string, config?: AxiosRequestConfig) =>{
+        const response = await axios.get<T, AxiosResponse<T, D>, D>(url, {
+            ...config,
+        });
         return response.data;
     },
     post: async <T, D>(url: string, data: D, config?: AxiosRequestConfig) => {

--- a/src/apis/rest-area/index.ts
+++ b/src/apis/rest-area/index.ts
@@ -1,0 +1,33 @@
+import { API } from '../api';
+
+import type {
+    HighwayRestAreaListParams,
+    HighwayRestAreaListResponse,
+    RestAreaDetailInfoParams,
+    RestAreaDetailInfoResponse,
+} from './type';
+
+export async function getHighwayRestAreaList({
+    from,
+    to,
+    roadNames,
+}: HighwayRestAreaListParams) {
+    return API.get<HighwayRestAreaListResponse, HighwayRestAreaListParams>(
+        `/api/highways/reststops`,
+        {
+            params: {
+                from,
+                to,
+                roadNames,
+            },
+        },
+    );
+}
+
+export async function getRestAreaDetailInfo({
+    reststopCode,
+}: RestAreaDetailInfoParams) {
+    return API.get<RestAreaDetailInfoResponse, RestAreaDetailInfoParams>(
+        `/api/reststops/${reststopCode}`,
+    );
+}

--- a/src/apis/rest-area/type.ts
+++ b/src/apis/rest-area/type.ts
@@ -1,0 +1,34 @@
+import type { RestAreaMenuDataType } from '#/types/menu';
+import type {
+    RestAreaAdditionalDataType,
+    RestAreaDetailAtHighwayType,
+    RestAreaGasStationDataType,
+    RestAreaParkingDataType,
+} from '#/types/rest-area';
+
+export interface HighwayRestAreaListParams {
+    from: string;
+    to: string;
+    roadNames: string;
+}
+
+export interface HighwayRestAreaListResponse {
+    totalReststopCount: number;
+    reststops: RestAreaDetailAtHighwayType[];
+}
+
+export interface RestAreaDetailInfoParams {
+    reststopCode: string;
+}
+
+export interface RestAreaDetailInfoResponse {
+    name: string; // 휴게소 이름
+    isOperating: boolean; // 식당 운영중 여부
+    startTime?: string; // 식당 운영 시작 시간 (옵션 필드)
+    endTime?: string; // 식당 운영 종료 시간 (옵션 필드)
+    naverRating?: number; // 네이버 평점 (옵션 필드, Float 대신 number 사용)
+    gasStationData: RestAreaGasStationDataType; // 주유소 정보
+    parkingData: RestAreaParkingDataType; // 주차 정보
+    reststopData: RestAreaAdditionalDataType; // 휴게소 기타 정보
+    menuData: RestAreaMenuDataType[]; // 메뉴 데이터 리스트
+}

--- a/src/apis/tmap/index.ts
+++ b/src/apis/tmap/index.ts
@@ -15,30 +15,23 @@ export async function getLocationSearchData({
     centerLon,
     centerLat,
     appKey,
-}: LocationSearchParams): Promise<LocationSearchResponse> {
-    const data = await API.get<LocationSearchParams>(`/tmap/pois`, {
-        page,
-        searchKeyword,
-        centerLon,
-        centerLat,
-        appKey,
+}: LocationSearchParams) {
+    return API.get<LocationSearchResponse, LocationSearchParams>(`/tmap/pois`, {
+        params: { page, searchKeyword, centerLon, centerLat, appKey },
     });
-    return data;
 }
 
 export async function getReverseGeocodingData({
     lat,
     lon,
     appKey,
-}: ReverseGeocodingParams): Promise<ReverseGeocodingResponse> {
-    const data = await API.get<ReverseGeocodingParams>(
-        `/tmap/geo/reversegeocoding`,
-        {
-            lat,
-            lon,
-            appKey,
-        },
-    );
+}: ReverseGeocodingParams) {
+    const data = await API.get<
+        ReverseGeocodingResponse,
+        ReverseGeocodingParams
+    >(`/tmap/geo/reversegeocoding`, {
+        params: { lat, lon, appKey },
+    });
     return data;
 }
 

--- a/src/constants/query-key.ts
+++ b/src/constants/query-key.ts
@@ -1,3 +1,4 @@
+import { HighwayRestAreaListParams } from '#/apis/rest-area/type';
 import type { GeolocationCoordinatesType } from '#/types/location';
 
 export const LOCATION_QUERY_KEY = {
@@ -18,5 +19,20 @@ export const LOCATION_QUERY_KEY = {
         'destination-path',
         start,
         end,
-    ]
+    ],
+};
+
+export const REST_AREA_QUERY_KEY = {
+    base: ['rest-area'],
+    detail: (restAreaCode: string) => [
+        ...REST_AREA_QUERY_KEY.base,
+        'detail',
+        restAreaCode,
+    ],
+    highwayList: ({ from, to, roadNames }: HighwayRestAreaListParams) => [
+        ...REST_AREA_QUERY_KEY.base,
+        'highway-list',
+        { from, to },
+        roadNames
+    ],
 };

--- a/src/query-hooks/location/query.ts
+++ b/src/query-hooks/location/query.ts
@@ -1,7 +1,6 @@
 import {
     useInfiniteQuery,
     useQuery,
-    useSuspenseQuery,
 } from '@tanstack/react-query';
 
 import {

--- a/src/query-hooks/rest-area/query.ts
+++ b/src/query-hooks/rest-area/query.ts
@@ -1,0 +1,51 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import { getHighwayRestAreaList, getRestAreaDetailInfo } from '#/apis/rest-area';
+import { HighwayRestAreaListParams } from '#/apis/rest-area/type';
+import { REST_AREA_QUERY_KEY } from '#/constants/query-key';
+
+export const useGetHighwayRestAreaList = ({
+    from,
+    to,
+    roadNames,
+}: HighwayRestAreaListParams) => {
+    return useSuspenseQuery({
+        queryKey: REST_AREA_QUERY_KEY.highwayList({ from, to, roadNames }),
+        queryFn: () => getHighwayRestAreaList({ from, to, roadNames }),
+    });
+};
+
+export const useGetRestAreaDetailInfo = (reststopCode: string) => {
+    return useSuspenseQuery({
+        queryKey: REST_AREA_QUERY_KEY.detail(reststopCode),
+        queryFn: () => getRestAreaDetailInfo({ reststopCode }),
+        staleTime: 1000 * 60,
+    })
+}
+
+export const useGetRestAreaGasStationInfo = (reststopCode: string) => {
+    return useSuspenseQuery({
+        queryKey: REST_AREA_QUERY_KEY.detail(reststopCode),
+        queryFn: () => getRestAreaDetailInfo({ reststopCode }),
+        select: (response) => response.gasStationData,
+        staleTime: 1000 * 60,
+    })
+}
+
+export const useGetRestAreaParkingInfo = (reststopCode: string) => {
+    return useSuspenseQuery({
+        queryKey: REST_AREA_QUERY_KEY.detail(reststopCode),
+        queryFn: () => getRestAreaDetailInfo({ reststopCode }),
+        select: (response) => response.parkingData,
+        staleTime: 1000 * 60,
+    })
+}
+
+export const useGetRestAreaMenuInfo = (reststopCode: string) => {
+    return useSuspenseQuery({
+        queryKey: REST_AREA_QUERY_KEY.detail(reststopCode),
+        queryFn: () => getRestAreaDetailInfo({ reststopCode }),
+        select: (response) => response.menuData,
+        staleTime: 1000 * 60,
+    })
+}

--- a/src/types/amenity.ts
+++ b/src/types/amenity.ts
@@ -1,0 +1,4 @@
+export interface AmenityType {
+    amenityName: string; // 편의시설 이름
+    amenityLogoUrl: string // 편의시설 로고 URL
+}

--- a/src/types/brand.ts
+++ b/src/types/brand.ts
@@ -1,0 +1,4 @@
+export interface BrandType {
+    brandName: string; // 브랜드 이름
+    brandLogoUrl: string; // 브랜드 로고 URL
+}

--- a/src/types/menu.ts
+++ b/src/types/menu.ts
@@ -1,0 +1,21 @@
+export interface RestAreaMenuDataType {
+    representativeMenuData: RepresentativeMenuDataType[]; // 대표 메뉴 데이터 (최대 2개)
+    totalMenuCount: number; // 전체 메뉴 개수
+    recommendedMenuData: MenuDataType[]; // 추천 메뉴 데이터 리스트
+    normalMenuData: MenuDataType[]; // 일반 메뉴 데이터 리스트
+}
+
+export interface MenuDataType {
+    menuName: string; // 메뉴 이름
+    menuPrice: number; // 메뉴 가격
+    isSignatureMenu: boolean; // 시그니처 메뉴 여부
+    isPopularMenu: boolean; // 인기 메뉴 여부
+    menuCategory: string; // 메뉴 카테고리
+}
+
+export interface RepresentativeMenuDataType {
+    representativeMenuName: string; // 대표 메뉴 이름
+    representativeMenuPrice: number; // 대표 메뉴 가격
+    representativeMenuImageUrl: string; // 대표 메뉴 이미지
+    representativeMenuDescription: string; // 대표 메뉴 설명
+}

--- a/src/types/rest-area.ts
+++ b/src/types/rest-area.ts
@@ -1,0 +1,46 @@
+import { AmenityType } from "./amenity";
+import { BrandType } from "./brand";
+import { MenuDataType, RepresentativeMenuDataType } from "./menu";
+import { RestaurantInfoType } from "./restaurant";
+
+export interface RestAreaDetailAtHighwayType {
+    name: string;
+    code: string;
+    isOperating: boolean;
+    gasolinePrice?: string;
+    dieselPrice?: string;
+    lpgPrice?: string;
+    naverRating: number;
+    foodMenusCount: number;
+}
+
+export interface RestAreaGasStationDataType {
+    gasolinePrice?: string;
+    dieselPrice?: string;
+    lpgPrice?: string;
+    isElectricChargingStation: boolean;
+    isHydrogenChargingStation: boolean;
+}
+
+export interface RestAreaParkingDataType {
+    smallCarSpace: number;
+    largeCarSpace: number;
+    disabledPersonSpace: number;
+    totalSpace: number;
+    updateDate: string;
+}
+
+export interface RestAreaAdditionalDataType {
+    restaurantOperatingTimes: RestaurantInfoType[]; // 운영 시간 리스트
+    brands: BrandType[]; // 브랜드 데이터 리스트
+    amenities: AmenityType[]; // 편의시설 데이터 리스트
+    address: string; // 주소
+    phoneNumber: string; // 전화번호
+}
+
+export interface RestAreaMenuDataType {
+    representativeMenuData: RepresentativeMenuDataType[]; // 대표 메뉴 데이터 (최대 2개)
+    totalMenuCount: number; // 전체 메뉴 개수
+    recommendedMenuData: MenuDataType[]; // 추천 메뉴 데이터 리스트
+    normalMenuData: MenuDataType[]; // 일반 메뉴 데이터 리스트
+}

--- a/src/types/restaurant.ts
+++ b/src/types/restaurant.ts
@@ -1,0 +1,4 @@
+export interface RestaurantInfoType {
+    restaurantName: string; // 식당 이름
+    operatingTime: string; // 운영 시간 (예: 09:00 ~ 21:00)
+}


### PR DESCRIPTION
## Task Summary ✨
휴게소 목록 및 상세 정보 API 추가 및 Type 정의

## Description 📑
- 시작과 도착 위경도를 기반으로 경유하는 휴게소 목록을 받아오는 API 및 Query Hook 정의
- 특정 휴게소 Code 를 기반으로 상세 정보를 조회하는 API 및 Query Hook 정의 (데이터 별로 Query Hook 분기 처리)
- 휴게소 정보, 주차 정보, 기타 정보, 메뉴 정보, 브랜드 및 편의 시설 관련 Type 및 Interface 정의

## More Information 🛎 (Optional)
- API.get 메서드도 이제 AxiosConfig 를 받도록 수정해서 관련 코드도 조금 수정했어.
- 우선 타입 정의 및 API, Query Hook 부터 만들고 각 섹션 별로 Hook 기반의 데이터 연동을 바로 진행할 거 같아!

## Self Checklist ✅
- [x] PR 제목 컨벤션에 맞는지 확인
- [x] PR Label 설정