### PR TITLE
[FIX] Tabheader가 짧은 콘텐츠에서 min header로 고정되는 문제 해결

### DIFF
--- a/src/components/tab-header/TabHeader.style.ts
+++ b/src/components/tab-header/TabHeader.style.ts
@@ -10,7 +10,8 @@ export const Container = styled.div`
     display: flex;
     flex-direction: column;
 
-    position: sticky;
+    position: absolute;
+    width: 375px;
     top: 0;
     background-color: ${theme.color.wht[100]};
 `;

--- a/src/pages/templates/rest-area-detail/RestAreaDetail.style.tsx
+++ b/src/pages/templates/rest-area-detail/RestAreaDetail.style.tsx
@@ -1,0 +1,7 @@
+import styled from '@emotion/styled';
+import { motion } from 'framer-motion';
+
+export const Contents = styled(motion.div)`
+    height: 100dvh;
+    overflow: scroll;
+`;

--- a/src/pages/templates/rest-area-detail/RestAreaDetail.tsx
+++ b/src/pages/templates/rest-area-detail/RestAreaDetail.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useRef, useState } from 'react';
 
-import { Outlet, useLocation } from 'react-router-dom';
+import { Outlet } from 'react-router-dom';
 
 import DotIcon from '#/assets/icons/dot.svg?react';
 import { TabHeader } from '#/components/tab-header';
-import useIntersectionObserver from '#/hooks/useIntersectionObserver';
 import { useGetRestAreaBaseInfo } from '#/query-hooks/rest-area/query';
+
+import * as S from './RestAreaDetail.style';
 
 const tabTitles = [
     { title: '먹거리', url: 'foods' },
@@ -21,36 +22,49 @@ const tabTitles = [
 ];
 
 export function RestAreaDetail() {
-    const location = useLocation();
-
-    const containerRef = useRef<HTMLDivElement>(null);
-    const tabHeaderRef = useRef<HTMLDivElement>(null);
-
     const [isMinHeader, setIsMinHeader] = useState(false);
 
     const { data: restInformation } = useGetRestAreaBaseInfo();
 
-    const { targetRef: contentRef } = useIntersectionObserver<HTMLDivElement>({
-        onIntersect: (isIntersect) => setIsMinHeader(isIntersect),
-        enabled: true,
-        rootMargin: `0px 0px ${-(containerRef.current?.offsetHeight ?? 0)}px 0px`,
-    });
+    const contentRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
-        setIsMinHeader(false);
-    }, [location]);
+        if (!contentRef.current) {
+            return;
+        }
+
+        const handleScroll = () => {
+            if (!contentRef.current) {
+                return;
+            }
+            const scrollTop = contentRef.current.scrollTop;
+            setIsMinHeader(scrollTop > 30);
+        };
+
+        contentRef.current.addEventListener('scroll', handleScroll);
+
+        return () => {
+            if (contentRef.current) {
+                contentRef.current.removeEventListener('scroll', handleScroll);
+            }
+        };
+    }, [contentRef]);
 
     return (
-        <div ref={containerRef}>
+        <div>
             <TabHeader
-                ref={tabHeaderRef}
                 headerInformation={restInformation}
                 tabTitles={tabTitles}
                 isMinSize={isMinHeader}
             />
-            <div ref={contentRef}>
+            <S.Contents
+                ref={contentRef}
+                animate={{
+                    paddingTop: isMinHeader ? '64px' : '214px',
+                }}
+            >
                 <Outlet />
-            </div>
+            </S.Contents>
         </div>
     );
 }

--- a/src/pages/templates/rest-area-detail/RestAreaDetail.tsx
+++ b/src/pages/templates/rest-area-detail/RestAreaDetail.tsx
@@ -1,6 +1,6 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
-import { Outlet } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router-dom';
 
 import DotIcon from '#/assets/icons/dot.svg?react';
 import { TabHeader } from '#/components/tab-header';
@@ -21,6 +21,8 @@ const tabTitles = [
 ];
 
 export function RestAreaDetail() {
+    const location = useLocation();
+
     const containerRef = useRef<HTMLDivElement>(null);
     const tabHeaderRef = useRef<HTMLDivElement>(null);
 
@@ -33,6 +35,10 @@ export function RestAreaDetail() {
         enabled: true,
         rootMargin: `0px 0px ${-(containerRef.current?.offsetHeight ?? 0)}px 0px`,
     });
+
+    useEffect(() => {
+        setIsMinHeader(false);
+    }, [location]);
 
     return (
         <div ref={containerRef}>

--- a/src/pages/templates/rest-area-detail/RestAreaDetail.tsx
+++ b/src/pages/templates/rest-area-detail/RestAreaDetail.tsx
@@ -31,7 +31,7 @@ export function RestAreaDetail() {
     const { targetRef: contentRef } = useIntersectionObserver<HTMLDivElement>({
         onIntersect: (isIntersect) => setIsMinHeader(isIntersect),
         enabled: true,
-        rootMargin: `0px 0px ${-((containerRef.current?.offsetHeight ?? 0) - (tabHeaderRef.current?.offsetHeight ?? 0) + 1)}px 0px`,
+        rootMargin: `0px 0px ${-(containerRef.current?.offsetHeight ?? 0)}px 0px`,
     });
 
     return (

--- a/src/pages/templates/rest-area-detail/RestAreaDetail.tsx
+++ b/src/pages/templates/rest-area-detail/RestAreaDetail.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 
-import { Outlet } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router-dom';
 
 import DotIcon from '#/assets/icons/dot.svg?react';
 import { TabHeader } from '#/components/tab-header';
@@ -22,11 +22,12 @@ const tabTitles = [
 ];
 
 export function RestAreaDetail() {
+    const location = useLocation();
+
     const [isMinHeader, setIsMinHeader] = useState(false);
+    const contentRef = useRef<HTMLDivElement>(null);
 
     const { data: restInformation } = useGetRestAreaBaseInfo();
-
-    const contentRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
         if (!contentRef.current) {
@@ -49,6 +50,14 @@ export function RestAreaDetail() {
             }
         };
     }, [contentRef]);
+    useEffect(() => {
+        if (contentRef.current) {
+            contentRef.current.scrollTo({
+                top: 0,
+                behavior: 'smooth',
+            });
+        }
+    }, [location]);
 
     return (
         <div>


### PR DESCRIPTION
## Task Summary ✨
<!-- 해당 PR 에서 작업한 메인 태스크에 대한 설명. -->

rootMargin 조절해서 Tabheader가 짧은 콘텐츠에서 min header로 고정되는 문제 해결

## Description 📑
<!-- 해당 PR 에 작업한 내용에 대한 구체적인 설명 -->

**as-is**

https://github.com/user-attachments/assets/5b255739-65a7-40e4-9534-5e92654d740d


**to-be**


https://github.com/user-attachments/assets/c2d9cdec-557f-4b2d-9bf3-c727dfc39ce3



intersection observer를 사용하는 방식이 아닌 scroll 이벤트를 사용해서 Tab header의 애니메이션을 구현했습니다.

## More Information 🛎 (Optional)
<!-- 해당 PR 에서 리뷰어들에게 추가로 전달할 정보 -->

## Self Checklist ✅
- [x] PR 제목 컨벤션에 맞는지 확인
- [x] PR Label 설정