### PR TITLE
[CHORE] 메인 페이지를 location-search 페이지로 바꾸기

### DIFF
--- a/src/routers/index.tsx
+++ b/src/routers/index.tsx
@@ -52,11 +52,6 @@ export const applicationRouter: ReturnType<typeof createBrowserRouter> =
                 {
                     path: '/',
                     errorElement: <div>에러</div>,
-                    element: <App />,
-                },
-                {
-                    path: '/location-search',
-                    errorElement: <div>에러</div>,
                     element: <LocationSearch />,
                 },
                 {


### PR DESCRIPTION
## Task Summary ✨
<!-- 해당 PR 에서 작업한 메인 태스크에 대한 설명. -->

메인 페이지를 location-search 페이지로 바꾸기

<img width="862" alt="스크린샷 2024-08-21 22 26 54" src="https://github.com/user-attachments/assets/7c4bd5c4-e45b-4689-9a8d-117a7bf46d15">

## Description 📑
<!-- 해당 PR 에 작업한 내용에 대한 구체적인 설명 -->

기존에 `/location-search` 경로에 있던 페이지의 경로를 root로 바꿨습니다.

## More Information 🛎 (Optional)
<!-- 해당 PR 에서 리뷰어들에게 추가로 전달할 정보 -->

## Self Checklist ✅
- [ ] PR 제목 컨벤션에 맞는지 확인
- [ ] PR Label 설정