### PR TITLE
[FIX] 휴게소 말풍선 마커 깨짐 현상 수정

### DIFF
--- a/src/features/rest-area/rest-area-bubble-marker/BubbleSideMarker.tsx
+++ b/src/features/rest-area/rest-area-bubble-marker/BubbleSideMarker.tsx
@@ -1,0 +1,159 @@
+import { theme } from "#/styles/theme";
+
+export const LeftSideBubbleMarker = () => (
+    <svg
+        width="13"
+        height="32"
+        viewBox="0 0 13 32"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+    >
+        <mask
+            id="mask0_1184_12593"
+            maskUnits="userSpaceOnUse"
+            x="0"
+            y="0"
+            width="13"
+            height="32"
+        >
+            <path d="M0 0H13V32H0V0Z" fill={theme.color.wht[100]} />
+        </mask>
+        <g mask="url(#mask0_1184_12593)">
+            <path
+                fill-rule="evenodd"
+                clip-rule="evenodd"
+                d="M8 0C3.58172 0 0 3.58172 0 8V24C0 28.4183 3.58172 32 8 32H150C154.418 32 158 28.4183 158 24V17.8169L163.901 6.46108C164.247 5.79539 163.764 5 163.013 5H157.418C156.232 2.06817 153.357 0 150 0H8Z"
+                fill="white"
+            />
+            <mask
+                id="mask1_1184_12593"
+                maskUnits="userSpaceOnUse"
+                x="0"
+                y="0"
+                width="165"
+                height="32"
+            >
+                <path
+                    fill-rule="evenodd"
+                    clip-rule="evenodd"
+                    d="M8 0C3.58172 0 0 3.58172 0 8V24C0 28.4183 3.58172 32 8 32H150C154.418 32 158 28.4183 158 24V17.8169L163.901 6.46108C164.247 5.79539 163.764 5 163.013 5H157.418C156.232 2.06817 153.357 0 150 0H8Z"
+                    fill="white"
+                />
+            </mask>
+            <g mask="url(#mask1_1184_12593)">
+                <path
+                    d="M158 17.8169L157.113 17.3559L157 17.5726V17.8169H158ZM157.418 5L156.492 5.37522L156.744 6H157.418V5ZM1 8C1 4.13401 4.13401 1 8 1V-1C3.02944 -1 -1 3.02944 -1 8H1ZM1 24V8H-1V24H1ZM8 31C4.134 31 1 27.866 1 24H-1C-1 28.9706 3.02943 33 8 33V31ZM150 31H8V33H150V31ZM157 24C157 27.866 153.866 31 150 31V33C154.971 33 159 28.9706 159 24H157ZM157 17.8169V24H159V17.8169H157ZM158.887 18.278L164.788 6.92217L163.013 5.99999L157.113 17.3559L158.887 18.278ZM164.788 6.92217C165.48 5.59077 164.514 4 163.013 4V5.99999L164.788 6.92217ZM163.013 4H157.418V6L163.013 5.99999V4ZM150 1C152.936 1 155.452 2.80802 156.492 5.37522L158.345 4.62478C157.011 1.32832 153.779 -1 150 -1V1ZM8 1H150V-1H8V1Z"
+                    fill={theme.color.main[100]}
+                />
+            </g>
+        </g>
+    </svg>
+);
+
+export const RightSideBubbleMarker = () => (
+    <svg
+        width="19"
+        height="32"
+        viewBox="0 0 19 32"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+    >
+        <mask
+            id="mask0_1184_12602"
+            maskUnits="userSpaceOnUse"
+            x="0"
+            y="0"
+            width="19"
+            height="32"
+        >
+            <path d="M19 0H0V32H19V0Z" fill={theme.color.wht[100]} />
+        </mask>
+        <g mask="url(#mask0_1184_12602)">
+            <path
+                fill-rule="evenodd"
+                clip-rule="evenodd"
+                d="M-137 0C-141.418 0 -145 3.58172 -145 8V24C-145 28.4183 -141.418 32 -137 32H5C9.418 32 13 28.4183 13 24V17.8169L18.901 6.46108C19.247 5.79539 18.764 5 18.013 5H12.418C11.232 2.06817 8.35699 0 5 0H-137Z"
+                fill="white"
+            />
+            <mask
+                id="mask1_1184_12602"
+                maskUnits="userSpaceOnUse"
+                x="-145"
+                y="0"
+                width="165"
+                height="32"
+            >
+                <path
+                    fill-rule="evenodd"
+                    clip-rule="evenodd"
+                    d="M-137 0C-141.418 0 -145 3.58172 -145 8V24C-145 28.4183 -141.418 32 -137 32H5C9.418 32 13 28.4183 13 24V17.8169L18.901 6.46108C19.247 5.79539 18.764 5 18.013 5H12.418C11.232 2.06817 8.35699 0 5 0H-137Z"
+                    fill="white"
+                />
+            </mask>
+            <g mask="url(#mask1_1184_12602)">
+                <path
+                    d="M13 17.8169L12.113 17.3559L12 17.5726V17.8169H13ZM12.418 5L11.492 5.37522L11.744 6H12.418V5ZM-144 8C-144 4.13401 -140.866 1 -137 1V-1C-141.971 -1 -146 3.02944 -146 8H-144ZM-144 24V8H-146V24H-144ZM-137 31C-140.866 31 -144 27.866 -144 24H-146C-146 28.9706 -141.971 33 -137 33V31ZM5 31H-137V33H5V31ZM12 24C12 27.866 8.866 31 5 31V33C9.97099 33 14 28.9706 14 24H12ZM12 17.8169V24H14V17.8169H12ZM13.887 18.278L19.788 6.92217L18.013 5.99999L12.113 17.3559L13.887 18.278ZM19.788 6.92217C20.48 5.59077 19.514 4 18.013 4V5.99999L19.788 6.92217ZM18.013 4H12.418V6L18.013 5.99999V4ZM5 1C7.936 1 10.452 2.80802 11.492 5.37522L13.345 4.62478C12.011 1.32832 8.77901 -1 5 -1V1ZM-137 1H5V-1H-137V1Z"
+                    fill={theme.color.main[100]}
+                />
+            </g>
+        </g>
+    </svg>
+);
+
+export const LeftSideRecommendMarker = () => (
+    <svg
+        width="13"
+        height="32"
+        viewBox="0 0 13 32"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+    >
+        <mask
+            id="mask0_1184_12611"
+            maskUnits="userSpaceOnUse"
+            x="0"
+            y="0"
+            width="13"
+            height="32"
+        >
+            <path d="M13 0H0V32H13V0Z" fill={theme.color.wht[100]} />
+        </mask>
+        <g mask="url(#mask0_1184_12611)">
+            <path
+                fill-rule="evenodd"
+                clip-rule="evenodd"
+                d="M8 0C3.58172 0 0 3.58172 0 8V24C0 28.4183 3.58171 32 7.99999 32H157.856C162.275 32 165.856 28.4183 165.856 24V18.0922L171.9 6.46108C172.246 5.79539 171.763 5 171.013 5H165.275C164.088 2.06817 161.214 0 157.856 0H8Z"
+                fill={theme.color.main[100]}
+            />
+        </g>
+    </svg>
+);
+
+export const RightSideRecommendMarker = () => (
+    <svg
+        width="19"
+        height="32"
+        viewBox="0 0 19 32"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+    >
+        <mask
+            id="mask0_1184_12616"
+            maskUnits="userSpaceOnUse"
+            x="0"
+            y="0"
+            width="19"
+            height="32"
+        >
+            <path d="M19 0H0V32H19V0Z" fill={theme.color.wht[100]} />
+        </mask>
+        <g mask="url(#mask0_1184_12616)">
+            <path
+                fill-rule="evenodd"
+                clip-rule="evenodd"
+                d="M-145 0C-149.418 0 -153 3.58172 -153 8V24C-153 28.4183 -149.418 32 -145 32H4.856C9.27501 32 12.856 28.4183 12.856 24V18.0922L18.9 6.46108C19.246 5.79539 18.763 5 18.013 5H12.275C11.088 2.06817 8.214 0 4.856 0H-145Z"
+                fill={theme.color.main[100]}
+            />
+        </g>
+    </svg>
+);

--- a/src/features/rest-area/rest-area-bubble-marker/BubbleSideMarker.tsx
+++ b/src/features/rest-area/rest-area-bubble-marker/BubbleSideMarker.tsx
@@ -20,8 +20,8 @@ export const LeftSideBubbleMarker = () => (
         </mask>
         <g mask="url(#mask0_1184_12593)">
             <path
-                fill-rule="evenodd"
-                clip-rule="evenodd"
+                fillRule="evenodd"
+                clipRule="evenodd"
                 d="M8 0C3.58172 0 0 3.58172 0 8V24C0 28.4183 3.58172 32 8 32H150C154.418 32 158 28.4183 158 24V17.8169L163.901 6.46108C164.247 5.79539 163.764 5 163.013 5H157.418C156.232 2.06817 153.357 0 150 0H8Z"
                 fill="white"
             />
@@ -34,8 +34,8 @@ export const LeftSideBubbleMarker = () => (
                 height="32"
             >
                 <path
-                    fill-rule="evenodd"
-                    clip-rule="evenodd"
+                    fillRule="evenodd"
+                    clipRule="evenodd"
                     d="M8 0C3.58172 0 0 3.58172 0 8V24C0 28.4183 3.58172 32 8 32H150C154.418 32 158 28.4183 158 24V17.8169L163.901 6.46108C164.247 5.79539 163.764 5 163.013 5H157.418C156.232 2.06817 153.357 0 150 0H8Z"
                     fill="white"
                 />
@@ -70,8 +70,8 @@ export const RightSideBubbleMarker = () => (
         </mask>
         <g mask="url(#mask0_1184_12602)">
             <path
-                fill-rule="evenodd"
-                clip-rule="evenodd"
+                fillRule="evenodd"
+                clipRule="evenodd"
                 d="M-137 0C-141.418 0 -145 3.58172 -145 8V24C-145 28.4183 -141.418 32 -137 32H5C9.418 32 13 28.4183 13 24V17.8169L18.901 6.46108C19.247 5.79539 18.764 5 18.013 5H12.418C11.232 2.06817 8.35699 0 5 0H-137Z"
                 fill="white"
             />
@@ -84,8 +84,8 @@ export const RightSideBubbleMarker = () => (
                 height="32"
             >
                 <path
-                    fill-rule="evenodd"
-                    clip-rule="evenodd"
+                    fillRule="evenodd"
+                    clipRule="evenodd"
                     d="M-137 0C-141.418 0 -145 3.58172 -145 8V24C-145 28.4183 -141.418 32 -137 32H5C9.418 32 13 28.4183 13 24V17.8169L18.901 6.46108C19.247 5.79539 18.764 5 18.013 5H12.418C11.232 2.06817 8.35699 0 5 0H-137Z"
                     fill="white"
                 />
@@ -120,8 +120,8 @@ export const LeftSideRecommendMarker = () => (
         </mask>
         <g mask="url(#mask0_1184_12611)">
             <path
-                fill-rule="evenodd"
-                clip-rule="evenodd"
+                fillRule="evenodd"
+                clipRule="evenodd"
                 d="M8 0C3.58172 0 0 3.58172 0 8V24C0 28.4183 3.58171 32 7.99999 32H157.856C162.275 32 165.856 28.4183 165.856 24V18.0922L171.9 6.46108C172.246 5.79539 171.763 5 171.013 5H165.275C164.088 2.06817 161.214 0 157.856 0H8Z"
                 fill={theme.color.main[100]}
             />
@@ -149,8 +149,8 @@ export const RightSideRecommendMarker = () => (
         </mask>
         <g mask="url(#mask0_1184_12616)">
             <path
-                fill-rule="evenodd"
-                clip-rule="evenodd"
+                fillRule="evenodd"
+                clipRule="evenodd"
                 d="M-145 0C-149.418 0 -153 3.58172 -153 8V24C-153 28.4183 -149.418 32 -145 32H4.856C9.27501 32 12.856 28.4183 12.856 24V18.0922L18.9 6.46108C19.246 5.79539 18.763 5 18.013 5H12.275C11.088 2.06817 8.214 0 4.856 0H-145Z"
                 fill={theme.color.main[100]}
             />

--- a/src/features/rest-area/rest-area-bubble-marker/RestAreaBubbleMarker.style.tsx
+++ b/src/features/rest-area/rest-area-bubble-marker/RestAreaBubbleMarker.style.tsx
@@ -17,32 +17,16 @@ export const Container = styled(FlexBox)(({ isRecommend }: ContainerProps) => {
 
     return css`
         width: max-content;
+        height: 32px;
+        max-height: 32px;
+
         padding: 4px 12px;
-        border-radius: 8px;
         background-color: ${backgroundColor};
-        border: 1px solid ${borderColor};
+        border-top: 1px solid ${borderColor};
+        border-bottom: 1px solid ${borderColor};
         box-sizing: border-box;
+        text-align: center;
         color: ${color};
-        position: relative;
-        align-items: center;
-
-        &::before {
-            content: '';
-            position: absolute;
-            top: 25%;
-            right: -6px;
-
-            width: 10px;
-            height: 10px;
-
-            background-color: ${backgroundColor};
-            transform: translateY(-50%) rotate(-27.5deg);
-            clip-path: polygon(100% 50%, 0 0, 0 100%);
-        }
-
-        & > svg {
-            margin: auto 0;
-        }
     `;
 });
 

--- a/src/features/rest-area/rest-area-bubble-marker/RestAreaBubbleMarker.style.tsx
+++ b/src/features/rest-area/rest-area-bubble-marker/RestAreaBubbleMarker.style.tsx
@@ -18,9 +18,8 @@ export const Container = styled(FlexBox)(({ isRecommend }: ContainerProps) => {
     return css`
         width: max-content;
         height: 32px;
-        max-height: 32px;
 
-        padding: 4px 12px;
+        padding: 4px 0;
         background-color: ${backgroundColor};
         border-top: 1px solid ${borderColor};
         border-bottom: 1px solid ${borderColor};

--- a/src/features/rest-area/rest-area-bubble-marker/RestAreaBubbleMarker.tsx
+++ b/src/features/rest-area/rest-area-bubble-marker/RestAreaBubbleMarker.tsx
@@ -4,9 +4,16 @@ import { renderToString } from 'react-dom/server';
 import { Marker } from 'react-naver-maps';
 
 import MarkerFlagIcon from '#/assets/icons/marker-flag.svg?react';
+import { FlexBox } from '#/components/flex-box';
 import { Text } from '#/components/text';
 import { useDisclosure } from '#/hooks/useDisclosure';
 
+import {
+    LeftSideBubbleMarker,
+    LeftSideRecommendMarker,
+    RightSideBubbleMarker,
+    RightSideRecommendMarker,
+} from './BubbleSideMarker';
 import * as S from './RestAreaBubbleMarker.style';
 
 export interface RestAreaBubbleMarkerImplProps extends ComponentProps<'div'> {
@@ -19,17 +26,31 @@ export const RestAreaBubbleMarkerImpl = forwardRef<
     HTMLDivElement,
     RestAreaBubbleMarkerImplProps
 >(({ isRecommend, restAreaName, direction, ...restProps }, ref) => {
+    const LeftSideMarker = isRecommend
+        ? LeftSideRecommendMarker
+        : LeftSideBubbleMarker;
+    const RightSideMarker = isRecommend
+        ? RightSideRecommendMarker
+        : RightSideBubbleMarker;
+
     return (
-        <S.Container
+        <FlexBox
             row
-            gap={4}
-            ref={ref}
-            isRecommend={isRecommend}
-            {...restProps}
+            flexOption={{ alignItems: 'center', justifyContent: 'center' }}
         >
-            {isRecommend && <MarkerFlagIcon color="inherit" />}
-            <Text typography="bodyBold14">{restAreaName}</Text>
-        </S.Container>
+            <LeftSideMarker />
+            <S.Container
+                row
+                gap={4}
+                ref={ref}
+                isRecommend={isRecommend}
+                {...restProps}
+            >
+                {isRecommend && <MarkerFlagIcon color="inherit" />}
+                <Text typography="bodyBold14">{restAreaName}</Text>
+            </S.Container>
+            <RightSideMarker />
+        </FlexBox>
     );
 });
 
@@ -53,8 +74,8 @@ export const RestAreaBubbleMarker = ({
                 direction={direction}
             />,
         ),
-        size: new naver.maps.Size(width + 8, 16),
-        anchor: new naver.maps.Point(width + 8, 16),
+        size: new naver.maps.Size(width + 40, 16),
+        anchor: new naver.maps.Point(width + 40, 16),
     };
 
     // NOTE : Emotion Style 을 적용하기 위해 Marker 컴포넌트와 RestAreaBubbleMarkerImpl 컴포넌트를 렌더링
@@ -65,9 +86,9 @@ export const RestAreaBubbleMarker = ({
                 ref={(element) => {
                     if (element && !isRender) {
                         const { width } = element.getBoundingClientRect();
+                        console.log(width);
                         setWidth(width);
                         turnOnRender();
-                        element.style.display = 'none';
                     }
                 }}
                 isRecommend={isRecommend}

--- a/src/features/rest-area/rest-area-bubble-marker/RestAreaBubbleMarker.tsx
+++ b/src/features/rest-area/rest-area-bubble-marker/RestAreaBubbleMarker.tsx
@@ -81,12 +81,12 @@ export const RestAreaBubbleMarker = ({
     // NOTE : Emotion Style 을 적용하기 위해 Marker 컴포넌트와 RestAreaBubbleMarkerImpl 컴포넌트를 렌더링
     return (
         <>
-            <Marker icon={icon} {...restProps} />
+            <Marker icon={icon} zIndex={Number(isRecommend)} {...restProps} />
             <RestAreaBubbleMarkerImpl
                 ref={(element) => {
                     if (element && !isRender) {
                         const { width } = element.getBoundingClientRect();
-                        console.log(width);
+                        element.style.display = 'none';
                         setWidth(width);
                         turnOnRender();
                     }


### PR DESCRIPTION
## Task Summary ✨
휴게소 말풍선 마커 깨짐 현상 수정

## Description 📑
- 말풍선 모양을 구성하는 좌, 우측 모형을 SVG 로 받아 컴포넌트화하여 사용하도록 했습니다.
- 기존의 `&::after` 로 구현했던 말풍선 모양을 SVG 로 대체하고 이를 이어 붙여 구현했습니다.

## More Information 🛎 (Optional)
- 이제 더 이상 깨지지 않는 말풍선...
![777](https://github.com/user-attachments/assets/a0b98a17-2434-4a1a-9af7-07d88ed05196)

## Self Checklist ✅
- [x] PR 제목 컨벤션에 맞는지 확인
- [x] PR Label 설정