### PR TITLE
[FIX] Drawer 렌더링 시 Bounce 되는 현상 제거

### DIFF
--- a/src/components/drawer/Drawer.style.tsx
+++ b/src/components/drawer/Drawer.style.tsx
@@ -22,14 +22,13 @@ export const ContentWrapper = styled(motion.div)`
     position: fixed;
     width: 375px;
     max-width: 375px;
-    max-height: 90dvh;
 
     padding: 0 16px;
 
     transform: translate(-50%, -50%);
     transition:
-        height 0.1s cubic-bezier(0.14, 0.99, 0.98, 0.98),
-        top 0.1s cubic-bezier(0.14, 0.99, 0.98, 0.98);
+        height 0.05s cubic-bezier(0.14, 0.89, 0.95, 0.98),
+        top 0.05s cubic-bezier(0.14, 0.89, 0.95, 0.98);
 
     background-color: ${theme.color.wht[100]};
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);

--- a/src/components/drawer/DrawerContent.tsx
+++ b/src/components/drawer/DrawerContent.tsx
@@ -109,6 +109,9 @@ export const DrawerContent = ({
                                 height,
                                 top,
                             }}
+                            transition={{
+                                layout: { duration: 0.05 }
+                            }}
                             layout
                             onPanStart={handlePanStart}
                             onPanEnd={handlePanEnd}

--- a/src/components/uncontrolled-drawer/UnControlledDrawer.style.tsx
+++ b/src/components/uncontrolled-drawer/UnControlledDrawer.style.tsx
@@ -16,14 +16,13 @@ export const ContentWrapper = styled(motion.div)`
     position: fixed;
     width: 375px;
     max-width: 375px;
-    max-height: 90dvh;
 
     padding: 0 16px;
 
     transform: translate(-50%, -50%);
     transition:
-        height 0.1s cubic-bezier(0.14, 0.99, 0.98, 0.98),
-        top 0.1s cubic-bezier(0.14, 0.99, 0.98, 0.98);
+        height 0.05s cubic-bezier(0.14, 0.99, 0.98, 0.98),
+        top 0.05s cubic-bezier(0.14, 0.99, 0.98, 0.98);
 
     background-color: ${theme.color.wht[100]};
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);

--- a/src/components/uncontrolled-drawer/UnControlledDrawerContent.tsx
+++ b/src/components/uncontrolled-drawer/UnControlledDrawerContent.tsx
@@ -109,6 +109,9 @@ export const UnControlledDrawerContent = ({
                                 height,
                                 top,
                             }}
+                            transition={{
+                                layout: { duration: 0.05 }
+                            }}
                             layout
                             onPanStart={handlePanStart}
                             onPanEnd={handlePanEnd}


### PR DESCRIPTION
## Task Summary ✨
Drawer 렌더링 시 Bounce 되는 현상 제거

## Description 📑
- DrawerContent 내 불필요하게 정의된 max-height 속성 제거 (사용자가 prop로 인계하므로)
- DrawerContent 의 height, max-height, top 속성 변경 시 layout Animation 에 transition 적용

## More Information 🛎 (Optional)
- framer-motion 에서 제공하는 motion 컴포넌트에 layout props 를 적용했기 때문에 transition 으로 제어가 가능해.
- 기존에 Drawer 가 Bounce 되어서 렌더링 된 원인은, layout 값은 즉시 변경되었으나 transition 스타일은 0.1 초간의 딜레이가 있었기 때문에 아래와 같은 문제를 야기했어.
    - motion 컴포넌트에서 style props 에 하드하게 적용된 top, height, max-height 속성이 먼저 즉시 변경됨
    - 이후 transition 이 적용되면서 top, height 속성이 이전 값으로 되돌아가고 다시 올라오는 현상 발생

## Self Checklist ✅
- [x] PR 제목 컨벤션에 맞는지 확인
- [x] PR Label 설정