### PR TITLE
[FEAT] 404, 500 페이지 템플릿 및 에러 컴포넌트 추가

### DIFF
--- a/src/components/async-boundary/AsyncBoundary.tsx
+++ b/src/components/async-boundary/AsyncBoundary.tsx
@@ -2,6 +2,8 @@ import { type ComponentProps, type PropsWithChildren, Suspense } from 'react';
 
 import { ErrorBoundary, type FallbackProps } from 'react-error-boundary';
 
+import { ErrorBox } from '../error-box';
+
 interface PropsType
     extends Omit<ComponentProps<typeof ErrorBoundary>, 'fallbackRender'> {
     pendingFallback: ComponentProps<typeof Suspense>['fallback'];
@@ -9,7 +11,9 @@ interface PropsType
 }
 
 // FIXME : 추후 에러 Fallback UI 시안이 나올 경우 대체해야 함
-const FallbackComponent = ({ error }: FallbackProps) => <p>{error.message}</p>;
+const FallbackComponent = ({ error }: FallbackProps) => (
+    <ErrorBox>{error.message}</ErrorBox>
+);
 
 export const AsyncBoundary = ({
     pendingFallback,

--- a/src/components/error-box/ErrorBox.style.tsx
+++ b/src/components/error-box/ErrorBox.style.tsx
@@ -1,0 +1,18 @@
+import styled from '@emotion/styled';
+
+import { FlexBox } from '../flex-box';
+
+export const Container = styled(FlexBox)`
+    align-items: center;
+`;
+
+export const TextSection = styled(FlexBox)`
+    text-align: center;
+    justify-content: center;
+`;
+
+export const ErrorImage = styled.img`
+    max-width: 375px;
+    max-height: 375px;
+    aspect-ratio: 1 / 1;
+`;

--- a/src/components/error-box/ErrorBox.tsx
+++ b/src/components/error-box/ErrorBox.tsx
@@ -11,7 +11,7 @@ export const ErrorBox = ({ children }: PropsWithChildren<unknown>) => (
         <S.ErrorImage
             width={225}
             height={225}
-            src="https://hyusik-matju-bucket.s3.ap-northeast-2.amazonaws.com/assets/error.png"
+            src={`${import.meta.env.VITE_ASSET_URL}/error.png`}
             alt="not_found"
         />
         <S.TextSection gap={4}>

--- a/src/components/error-box/ErrorBox.tsx
+++ b/src/components/error-box/ErrorBox.tsx
@@ -1,0 +1,27 @@
+import { PropsWithChildren } from 'react';
+
+import { theme } from '#/styles/theme';
+
+import { Text } from '../text';
+
+import * as S from './ErrorBox.style';
+
+export const ErrorBox = ({ children }: PropsWithChildren<unknown>) => (
+    <S.Container gap={8}>
+        <S.ErrorImage
+            width={225}
+            height={225}
+            src="https://hyusik-matju-bucket.s3.ap-northeast-2.amazonaws.com/assets/error.png"
+            alt="not_found"
+        />
+        <S.TextSection gap={4}>
+            <Text typography="bodyMedium16" color={theme.color.blk[40]}>
+                이런! 에러가 발생했습니다.
+            </Text>
+            <Text typography="bodyMedium16" color={theme.color.blk[40]}>
+                새로고침 후 다시 시도해주세요.
+            </Text>
+        </S.TextSection>
+        {children}
+    </S.Container>
+);

--- a/src/components/error-box/index.ts
+++ b/src/components/error-box/index.ts
@@ -1,0 +1,1 @@
+export { ErrorBox } from './ErrorBox';

--- a/src/pages/internal-error/InternalErrorPage.style.tsx
+++ b/src/pages/internal-error/InternalErrorPage.style.tsx
@@ -1,0 +1,23 @@
+import styled from '@emotion/styled';
+
+import { FlexBox } from '#/components/flex-box';
+import { theme } from '#/styles/theme';
+
+export const Container = styled(FlexBox)`
+    height: 100dvh;
+    align-items: center;
+    justify-content: center;
+    margin: auto;
+`
+
+export const PreviousButton = styled.button`
+      width: 100%;
+        display: flex;
+        justify-content: center;
+        padding: 16px;
+        margin-top: 8px;
+        border-radius: 16px;
+
+        background-color: ${theme.color.main[100]};
+        cursor: pointer;
+`

--- a/src/pages/internal-error/InternalErrorPage.style.tsx
+++ b/src/pages/internal-error/InternalErrorPage.style.tsx
@@ -8,16 +8,16 @@ export const Container = styled(FlexBox)`
     align-items: center;
     justify-content: center;
     margin: auto;
-`
+`;
 
 export const PreviousButton = styled.button`
-      width: 100%;
-        display: flex;
-        justify-content: center;
-        padding: 16px;
-        margin-top: 8px;
-        border-radius: 16px;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    padding: 16px;
+    margin-top: 8px;
+    border-radius: 16px;
 
-        background-color: ${theme.color.main[100]};
-        cursor: pointer;
-`
+    background-color: ${theme.color.main[100]};
+    cursor: pointer;
+`;

--- a/src/pages/internal-error/InternalErrorPage.tsx
+++ b/src/pages/internal-error/InternalErrorPage.tsx
@@ -1,0 +1,33 @@
+import { useNavigate } from 'react-router-dom';
+
+import { ErrorBox } from '#/components/error-box';
+import { Text } from '#/components/text';
+import { MobileView } from '#/pages/templates/mobile-view';
+import { theme } from '#/styles/theme';
+
+import * as S from './InternalErrorPage.style';
+
+export const InternalErrorPage = () => {
+    const navigate = useNavigate();
+
+    const handleBackPreviousPage = () => {
+        navigate(-1);
+    };
+
+    return (
+        <MobileView>
+            <S.Container>
+                <ErrorBox>
+                    <S.PreviousButton onClick={handleBackPreviousPage}>
+                        <Text
+                            color={theme.color.wht[100]}
+                            typography="buttonBold16"
+                        >
+                            뒤로 가기
+                        </Text>
+                    </S.PreviousButton>
+                </ErrorBox>
+            </S.Container>
+        </MobileView>
+    );
+};

--- a/src/pages/internal-error/index.ts
+++ b/src/pages/internal-error/index.ts
@@ -1,0 +1,1 @@
+export { InternalErrorPage } from './InternalErrorPage';

--- a/src/pages/not-found/NotFoundPage.style.tsx
+++ b/src/pages/not-found/NotFoundPage.style.tsx
@@ -1,0 +1,10 @@
+import styled from '@emotion/styled';
+
+import { FlexBox } from '#/components/flex-box';
+
+export const Container = styled(FlexBox)`
+    height: 100dvh;
+    align-items: center;
+    justify-content: center;
+    margin: auto;
+`

--- a/src/pages/not-found/NotFoundPage.style.tsx
+++ b/src/pages/not-found/NotFoundPage.style.tsx
@@ -1,10 +1,29 @@
 import styled from '@emotion/styled';
 
 import { FlexBox } from '#/components/flex-box';
+import { theme } from '#/styles/theme';
 
 export const Container = styled(FlexBox)`
     height: 100dvh;
     align-items: center;
     justify-content: center;
     margin: auto;
+`;
+
+export const NotFoundSection = styled(FlexBox)`
+    justify-content: center;
+    align-items: center;
+    text-align: center;
 `
+
+export const PreviousButton = styled.button`
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    padding: 16px;
+    margin-top: 8px;
+    border-radius: 16px;
+
+    background-color: ${theme.color.main[100]};
+    cursor: pointer;
+`;

--- a/src/pages/not-found/NotFoundPage.tsx
+++ b/src/pages/not-found/NotFoundPage.tsx
@@ -1,0 +1,22 @@
+import { FlexBox } from '#/components/flex-box';
+import { Text } from '#/components/text';
+import { MobileView } from '#/pages/templates/mobile-view';
+import { theme } from '#/styles/theme';
+
+import * as S from './NotFoundPage.style';
+
+export const NotFoundPage = () => (
+    <MobileView>
+        <S.Container>
+            <FlexBox gap={8} flexOption={{ alignContent: 'center' }}>
+                <img
+                    src="https://hyusik-matju-bucket.s3.ap-northeast-2.amazonaws.com/assets/not-found.png"
+                    alt="not_found"
+                />
+                <Text typography="bodyMedium16" color={theme.color.blk[40]}>
+                    찾을 수 없는 페이지 입니다.
+                </Text>
+            </FlexBox>
+        </S.Container>
+    </MobileView>
+);

--- a/src/pages/not-found/NotFoundPage.tsx
+++ b/src/pages/not-found/NotFoundPage.tsx
@@ -1,3 +1,5 @@
+import { useNavigate } from 'react-router-dom';
+
 import { FlexBox } from '#/components/flex-box';
 import { Text } from '#/components/text';
 import { MobileView } from '#/pages/templates/mobile-view';
@@ -5,18 +7,34 @@ import { theme } from '#/styles/theme';
 
 import * as S from './NotFoundPage.style';
 
-export const NotFoundPage = () => (
-    <MobileView>
-        <S.Container>
-            <FlexBox gap={8} flexOption={{ alignContent: 'center' }}>
-                <img
-                    src="https://hyusik-matju-bucket.s3.ap-northeast-2.amazonaws.com/assets/not-found.png"
-                    alt="not_found"
-                />
-                <Text typography="bodyMedium16" color={theme.color.blk[40]}>
-                    찾을 수 없는 페이지 입니다.
-                </Text>
-            </FlexBox>
-        </S.Container>
-    </MobileView>
-);
+export const NotFoundPage = () => {
+    const navigate = useNavigate();
+
+    const handleBackPreviousPage = () => {
+        navigate(-1);
+    };
+
+    return (
+        <MobileView>
+            <S.Container>
+                <S.NotFoundSection gap={8}>
+                    <img
+                        src="https://hyusik-matju-bucket.s3.ap-northeast-2.amazonaws.com/assets/not-found.png"
+                        alt="not_found"
+                    />
+                    <Text typography="bodyMedium16" color={theme.color.blk[40]}>
+                        찾을 수 없는 페이지 입니다.
+                    </Text>
+                    <S.PreviousButton onClick={handleBackPreviousPage}>
+                        <Text
+                            color={theme.color.wht[100]}
+                            typography="buttonBold16"
+                        >
+                            뒤로 가기
+                        </Text>
+                    </S.PreviousButton>
+                </S.NotFoundSection>
+            </S.Container>
+        </MobileView>
+    );
+};

--- a/src/pages/not-found/NotFoundPage.tsx
+++ b/src/pages/not-found/NotFoundPage.tsx
@@ -18,7 +18,7 @@ export const NotFoundPage = () => {
             <S.Container>
                 <S.NotFoundSection gap={8}>
                     <img
-                        src="https://hyusik-matju-bucket.s3.ap-northeast-2.amazonaws.com/assets/not-found.png"
+                        src={`${import.meta.env.VITE_ASSET_URL}/not-found.png`}
                         alt="not_found"
                     />
                     <Text typography="bodyMedium16" color={theme.color.blk[40]}>

--- a/src/pages/not-found/NotFoundPage.tsx
+++ b/src/pages/not-found/NotFoundPage.tsx
@@ -1,6 +1,5 @@
 import { useNavigate } from 'react-router-dom';
 
-import { FlexBox } from '#/components/flex-box';
 import { Text } from '#/components/text';
 import { MobileView } from '#/pages/templates/mobile-view';
 import { theme } from '#/styles/theme';
@@ -23,7 +22,7 @@ export const NotFoundPage = () => {
                         alt="not_found"
                     />
                     <Text typography="bodyMedium16" color={theme.color.blk[40]}>
-                        찾을 수 없는 페이지 입니다.
+                        유효하지 않은 페이지 입니다.
                     </Text>
                     <S.PreviousButton onClick={handleBackPreviousPage}>
                         <Text

--- a/src/pages/not-found/index.ts
+++ b/src/pages/not-found/index.ts
@@ -1,0 +1,1 @@
+export { NotFoundPage } from './NotFoundPage';

--- a/src/pages/rest-area-map/index.tsx
+++ b/src/pages/rest-area-map/index.tsx
@@ -69,7 +69,7 @@ export const RestAreaMapPage = () => {
                 {isValidHighwayRestArea && (
                     <RestAreaListDrawer
                         totalRestAreaCount={restAreaData.totalReststopCount}
-                        restAreaList={restAreaData.reststopsdfs}
+                        restAreaList={restAreaData.reststops}
                     />
                 )}
                 <NaverMap maxBounds={mapBound}>

--- a/src/pages/rest-area-map/index.tsx
+++ b/src/pages/rest-area-map/index.tsx
@@ -69,7 +69,7 @@ export const RestAreaMapPage = () => {
                 {isValidHighwayRestArea && (
                     <RestAreaListDrawer
                         totalRestAreaCount={restAreaData.totalReststopCount}
-                        restAreaList={restAreaData.reststops}
+                        restAreaList={restAreaData.reststopsdfs}
                     />
                 )}
                 <NaverMap maxBounds={mapBound}>

--- a/src/routers/index.tsx
+++ b/src/routers/index.tsx
@@ -6,6 +6,7 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { NavermapsProvider } from 'react-naver-maps';
 import { Outlet, createBrowserRouter } from 'react-router-dom';
 
+import { NotFoundPage } from '#/pages/not-found';
 import { LocationSearch } from '#/pages/location-search';
 import { RestAreaFoodPage } from '#/pages/rest-area-food';
 import { RestAreaFuelPage } from '#/pages/rest-area-fuel';
@@ -78,5 +79,6 @@ export const applicationRouter: ReturnType<typeof createBrowserRouter> =
                     element: <RestAreaMapPage />,
                 },
             ],
+            errorElement: <NotFoundPage />,
         },
     ]);

--- a/src/routers/index.tsx
+++ b/src/routers/index.tsx
@@ -6,8 +6,9 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { NavermapsProvider } from 'react-naver-maps';
 import { Outlet, createBrowserRouter } from 'react-router-dom';
 
-import { NotFoundPage } from '#/pages/not-found';
+import { InternalErrorPage } from '#/pages/internal-error';
 import { LocationSearch } from '#/pages/location-search';
+import { NotFoundPage } from '#/pages/not-found';
 import { RestAreaFoodPage } from '#/pages/rest-area-food';
 import { RestAreaFuelPage } from '#/pages/rest-area-fuel';
 import { RestAreaMapPage } from '#/pages/rest-area-map';
@@ -51,12 +52,12 @@ export const applicationRouter: ReturnType<typeof createBrowserRouter> =
             children: [
                 {
                     path: '/',
-                    errorElement: <div>에러</div>,
+                    errorElement: <InternalErrorPage />,
                     element: <LocationSearch />,
                 },
                 {
                     path: '/rest-area/:restAreaId',
-                    errorElement: <div>에러</div>,
+                    errorElement: <InternalErrorPage />,
                     element: <RestAreaDetail />,
                     children: [
                         {
@@ -75,7 +76,7 @@ export const applicationRouter: ReturnType<typeof createBrowserRouter> =
                 },
                 {
                     path: '/map',
-                    errorElement: <div>에러</div>,
+                    errorElement: <InternalErrorPage />,
                     element: <RestAreaMapPage />,
                 },
             ],

--- a/src/routers/index.tsx
+++ b/src/routers/index.tsx
@@ -80,6 +80,11 @@ export const applicationRouter: ReturnType<typeof createBrowserRouter> =
                     element: <RestAreaMapPage />,
                 },
             ],
-            errorElement: <NotFoundPage />,
+            errorElement: (
+                <>
+                    <GlobalStyle />
+                    <NotFoundPage />
+                </>
+            ),
         },
     ]);


### PR DESCRIPTION
## Task Summary ✨
404, 500 페이지 템플릿 및 에러 컴포넌트 추가

## Description 📑
- 존재하지 않는 페이지 접근 시 NotFoundPage 를 렌더링 하도록 수정했습니다.
- 페이지 렌더링 과정에서 에러 발생 시 InternalErrorPage 를 렌더링 하도록 수정했습니다.
- ErrorBoundary 에서 fallbackRender 에 default 로 들어갈 ErrorBox 컴포넌트를 추가했습니다.

## More Information 🛎 (Optional)
|404|500|errorBox|
|---|---|---|
|<img width="338" alt="스크린샷 2024-08-21 22 30 54" src="https://github.com/user-attachments/assets/74e9601e-bd4e-4309-b7e7-8758b19c505b">|<img width="338" alt="스크린샷 2024-08-21 22 30 54" src="https://github.com/user-attachments/assets/57121275-60ba-464b-86f5-d3683aa666fb">|<img width="240" alt="스크린샷 2024-08-21 22 34 06" src="https://github.com/user-attachments/assets/f4667199-bb2f-4974-be2f-bca593c2400a">|
- @jhj2713 ErrorBox 컴포넌트 구조나 이런걸 보면 알겠지만 상당히 부족하고 날림 처리된 부분이라, 나중에 고도화를 할 때 개선하면 좋을 거 같아!


## Self Checklist ✅
- [x] PR 제목 컨벤션에 맞는지 확인
- [x] PR Label 설정