### PR TITLE
[FIX] representative 레이아웃 및 애니메이션 수정

### DIFF
--- a/src/features/rest-area/representative-menu-section/RepresentativeMenuSection.style.tsx
+++ b/src/features/rest-area/representative-menu-section/RepresentativeMenuSection.style.tsx
@@ -35,7 +35,7 @@ export const BestMenuImage = styled.img`
     width: 180px;
     height: 180px;
 
-    margin: 32px 0 20px 0;
+    margin: 28px 0 20px 0;
     border-radius: 180px;
 `;
 
@@ -47,6 +47,8 @@ export const PaginationSection = styled(FlexBox)`
     width: 100%;
     align-items: center;
     justify-content: center;
+    background-color: ${theme.color.wht[100]};
+    padding-bottom: 40px;
 `;
 
 export const PaginationIcon = styled.div(

--- a/src/features/rest-area/representative-menu-section/RepresentativeMenuSection.tsx
+++ b/src/features/rest-area/representative-menu-section/RepresentativeMenuSection.tsx
@@ -1,4 +1,6 @@
-import { useMotionValue, useTransform } from 'framer-motion';
+import { useEffect, useState } from 'react';
+
+import { useMotionValue, useSpring, useTransform } from 'framer-motion';
 
 import AlternativeImage from '#/assets/images/alternative-image.png';
 import { FlexBox } from '#/components/flex-box';
@@ -15,15 +17,21 @@ export const RepresentativeMenuSection = () => {
 
     const isNeedPagination = representativeMenuData.length > 1;
     const selectedMenuIndex = useMotionValue(0);
-    const translateX = useTransform(selectedMenuIndex, [0, 1], [0, -375]);
+    const rawTranslateX = useTransform(selectedMenuIndex, [0, 1], [0, -375]);
+    const translateX = useSpring(rawTranslateX, {
+        stiffness: 300,
+        damping: 30,
+    });
+
+    const [selectedIndex, setSelectedIndex] = useState(0);
+
+    useEffect(() => {
+        selectedMenuIndex.on('change', (latest) => setSelectedIndex(latest));
+    }, [selectedMenuIndex]);
 
     return (
         <S.Container>
-            <S.BestMenuContainer
-                row
-                style={{ translateX }}
-                transition={{ type: "spring", stiffness: 100, duration: 0.2 }}
-            >
+            <S.BestMenuContainer row style={{ translateX }}>
                 {representativeMenuData.map(
                     (
                         {
@@ -51,7 +59,7 @@ export const RepresentativeMenuSection = () => {
                                     event.currentTarget.src = AlternativeImage;
                                 }}
                             />
-                            <FlexBox gap={20}>
+                            <FlexBox gap={16}>
                                 <FlexBox gap={8}>
                                     <S.Description
                                         typography="bodyMedium16"
@@ -83,7 +91,7 @@ export const RepresentativeMenuSection = () => {
                         {representativeMenuData.map((_, index) => (
                             <S.PaginationIcon
                                 key={`pagination_${index + 1}`}
-                                isActive={index === 0}
+                                isActive={selectedIndex === index}
                                 onClick={() => selectedMenuIndex.set(index)}
                             />
                         ))}


### PR DESCRIPTION
## Task Summary ✨
<!-- 해당 PR 에서 작업한 메인 태스크에 대한 설명. -->

**메뉴가 하나일때**

<img width="352" alt="스크린샷 2024-08-24 00 05 20" src="https://github.com/user-attachments/assets/53fc1348-2c7b-479b-9483-7f03993ab1fd">

**메뉴가 두 개일때**



https://github.com/user-attachments/assets/64968490-566f-46d2-8cb7-ba88a2175e18


## Description 📑
<!-- 해당 PR 에 작업한 내용에 대한 구체적인 설명 -->

- representative 레이아웃 이상한 부분 수정
- 애니메이션 코드 수정

## More Information 🛎 (Optional)
<!-- 해당 PR 에서 리뷰어들에게 추가로 전달할 정보 -->

- useTransform으로만 하니까 자연스럽게 움직이는 애니메이션이 안 들어가서 useSpring까지 함께 넣어줬습니다
- selectedMenuIndex는 리렌더링을 발생시키지 않는 값이기 때문에 menu data의 selected 상태를 관리하는 state(selectedIndex)를 하나 더 선언해서 isActive props를 넘겨줬습니다

## Self Checklist ✅
- [x] PR 제목 컨벤션에 맞는지 확인
- [x] PR Label 설정