### PR TITLE
[FEAT] tab header 뒤로가기 및 destination indicator 클릭 로직 구현

### DIFF
--- a/src/components/tab-header/TabHeader.tsx
+++ b/src/components/tab-header/TabHeader.tsx
@@ -163,7 +163,9 @@ const TabHeader = forwardRef<HTMLDivElement, TabHeaderProps>(function TabHeader(
                                         ? theme.color.main[100]
                                         : theme.color.blk[40]
                                 }
-                                onClick={() => navigate(tabTitle.url)}
+                                onClick={() =>
+                                    navigate(tabTitle.url, { replace: true })
+                                }
                             >
                                 {tabTitle.title}
                             </S.TabTitle>

--- a/src/features/rest-area/destination-indicator/DestinationIndicator.tsx
+++ b/src/features/rest-area/destination-indicator/DestinationIndicator.tsx
@@ -6,22 +6,30 @@ import * as S from './DestinationIndicator.style';
 interface DestinationIndicatorProps {
     start: string;
     end: string;
+    onClick: () => void;
 }
 
 export const DestinationIndicator = ({
     start = '',
     end = '',
+    onClick,
 }: DestinationIndicatorProps) => {
     return (
-        <S.Container>
+        <S.Container onClick={onClick}>
             <S.Destination>
-                <S.DestinationText typography="bodyMedium16" color={theme.color.blk[60]}>
+                <S.DestinationText
+                    typography="bodyMedium16"
+                    color={theme.color.blk[60]}
+                >
                     {start}
                 </S.DestinationText>
             </S.Destination>
             <ArrowRightIcon color={theme.color.main[50]} />
             <S.Destination>
-                <S.DestinationText typography="bodyMedium16" color={theme.color.blk[60]}>
+                <S.DestinationText
+                    typography="bodyMedium16"
+                    color={theme.color.blk[60]}
+                >
                     {end}
                 </S.DestinationText>
             </S.Destination>

--- a/src/pages/location-search/LocationSearch.tsx
+++ b/src/pages/location-search/LocationSearch.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { flushSync } from 'react-dom';
+import { useLocation } from 'react-router-dom';
 
 import { Drawer } from '#/components/drawer';
 import { SEARCH_OPTION } from '#/constants/location';
@@ -12,6 +13,9 @@ import { SelectedLocationType } from '#/types/location';
 type SearchOptionType = (typeof SEARCH_OPTION)[keyof typeof SEARCH_OPTION];
 
 export function LocationSearch() {
+    const location = useLocation();
+    const { state } = location;
+
     const [routeLocation, setRouteLocation] = useState<
         Record<SearchOptionType, SelectedLocationType | null>
     >({
@@ -26,6 +30,13 @@ export function LocationSearch() {
 
     const [isCurrentLocationSearch, setIsCurrentLocationSearch] =
         useState<boolean>(false);
+
+    useEffect(() => {
+        if (state) {
+            const { origin, destination } = state;
+            setRouteLocation({ origin, destination });
+        }
+    }, [state]);
 
     const handleSelectLocation = (location: SelectedLocationType) => {
         if (!searchOption) {

--- a/src/pages/rest-area-map/index.tsx
+++ b/src/pages/rest-area-map/index.tsx
@@ -4,7 +4,7 @@ import {
     Polyline,
     useNavermaps,
 } from 'react-naver-maps';
-import { type Location, useLocation } from 'react-router-dom';
+import { type Location, useLocation, useNavigate } from 'react-router-dom';
 
 import { DestinationIndicator } from '#/features/rest-area/destination-indicator';
 import { DestinationMarker } from '#/features/rest-area/destination-marker';
@@ -19,6 +19,7 @@ export const RestAreaMapPage = () => {
     const naverMaps = useNavermaps();
     const location: Location<Record<SearchOptionType, SelectedLocationType>> =
         useLocation();
+    const navigate = useNavigate();
 
     const { origin, destination } = location.state;
 
@@ -61,6 +62,9 @@ export const RestAreaMapPage = () => {
             <DestinationIndicator
                 start={origin.addressName}
                 end={destination.addressName}
+                onClick={() =>
+                    navigate('/', { state: { origin, destination } })
+                }
             />
             {isValidHighwayRestArea && (
                 <RestAreaListDrawer


### PR DESCRIPTION
## Task Summary ✨
<!-- 해당 PR 에서 작업한 메인 태스크에 대한 설명. -->

https://github.com/user-attachments/assets/ae314ae3-5438-493d-9ee5-1a922d8ab10e


## Description 📑
<!-- 해당 PR 에 작업한 내용에 대한 구체적인 설명 -->

- tab header 뒤로가기 구현
- Destination Indicator 클릭 로직 구현

## More Information 🛎 (Optional)
<!-- 해당 PR 에서 리뷰어들에게 추가로 전달할 정보 -->


### Tab Header 뒤로가기

탭 클릭 시 navigate option을 replace로 줘서 뒤로가기를 했을 때 무조건 map으로 돌아갈 수 있도록 했습니다.

### Destination Indicator 클릭

Destination Indicator를 클릭 시 다시 검색 화면으로 돌아가서 도착지/출발지를 변경할 수 있어야 하는데 그 로직이 없던것 같아서 추가해뒀습니다.


## Self Checklist ✅
- [x] PR 제목 컨벤션에 맞는지 확인
- [x] PR Label 설정